### PR TITLE
Add ability list remote segments from min offset

### DIFF
--- a/core/src/main/scala/kafka/log/remote/RemoteStorageManager.scala
+++ b/core/src/main/scala/kafka/log/remote/RemoteStorageManager.scala
@@ -52,7 +52,19 @@ trait RemoteStorageManager extends Configurable with AutoCloseable {
    * @return List of remote segments, sorted by baseOffset in ascending order.
    */
   @throws(classOf[IOException])
-  def listRemoteSegments(topicPartition: TopicPartition): util.List[RemoteLogSegmentInfo]
+  def listRemoteSegments(topicPartition: TopicPartition): util.List[RemoteLogSegmentInfo] = {
+    listRemoteSegments(topicPartition, 0)
+  }
+
+  /**
+   * List the remote log segment files of the specified topicPartition starting from the base offset minBaseOffset.
+   * The RLM of a follower uses this method to find out the remote data
+   *
+   * @param minBaseOffset The minimum base offset for a segment to be returned.
+   * @return List of remote segments starting from the base offset minBaseOffset, sorted by baseOffset in ascending order.
+   */
+  @throws(classOf[IOException])
+  def listRemoteSegments(topicPartition: TopicPartition, minBaseOffset: Long): util.List[RemoteLogSegmentInfo]
 
   /**
    * Called by the RLM to retrieve the RemoteLogIndex entries of the specified remoteLogSegment.

--- a/core/src/test/scala/unit/kafka/log/remote/RemoteLogManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/remote/RemoteLogManagerTest.scala
@@ -187,7 +187,7 @@ class MockRemoteStorageManager extends RemoteStorageManager {
 
   override def cancelCopyingLogSegment(topicPartition: TopicPartition): Unit = {}
 
-  override def listRemoteSegments(topicPartition: TopicPartition): util.List[RemoteLogSegmentInfo] = Collections.emptyList()
+  override def listRemoteSegments(topicPartition: TopicPartition, minBaseOffset: Long): util.List[RemoteLogSegmentInfo] = Collections.emptyList()
 
   override def getRemoteLogIndexEntries(remoteLogSegment: RemoteLogSegmentInfo): util.List[RemoteLogIndexEntry] = Collections.emptyList()
 

--- a/remote-storage-managers/hdfs/src/main/java/org/apache/kafka/rsm/hdfs/HDFSRemoteStorageManager.java
+++ b/remote-storage-managers/hdfs/src/main/java/org/apache/kafka/rsm/hdfs/HDFSRemoteStorageManager.java
@@ -139,7 +139,7 @@ public class HDFSRemoteStorageManager implements RemoteStorageManager {
     }
 
     @Override
-    public List<RemoteLogSegmentInfo> listRemoteSegments(TopicPartition topicPartition) throws IOException {
+    public List<RemoteLogSegmentInfo> listRemoteSegments(TopicPartition topicPartition, long minBaseOffset) throws IOException {
         ArrayList<RemoteLogSegmentInfo> segments = new ArrayList<>();
 
         FileSystem fs = getFS();
@@ -152,9 +152,11 @@ public class HDFSRemoteStorageManager implements RemoteStorageManager {
             if (m.matches()) {
                 try {
                     long baseOffset = Long.parseLong(m.group(1));
-                    long endOffset = Long.parseLong(m.group(2));
-                    HDFSRemoteLogSegmentInfo segment = new HDFSRemoteLogSegmentInfo(baseOffset, endOffset, file.getPath());
-                    segments.add(segment);
+                    if (baseOffset >= minBaseOffset) {
+                        long endOffset = Long.parseLong(m.group(2));
+                        HDFSRemoteLogSegmentInfo segment = new HDFSRemoteLogSegmentInfo(baseOffset, endOffset, file.getPath());
+                        segments.add(segment);
+                    }
                 } catch (NumberFormatException e) {
                 }
             }

--- a/remote-storage-managers/hdfs/src/test/java/org/apache/kafka/rsm/hdfs/HDFSRemoteStorageManagerTest.java
+++ b/remote-storage-managers/hdfs/src/test/java/org/apache/kafka/rsm/hdfs/HDFSRemoteStorageManagerTest.java
@@ -390,4 +390,28 @@ public class HDFSRemoteStorageManagerTest {
         indexEntries = rsm1.copyLogSegment(tp4, seg);
         assertEquals(3, indexEntries.size());
     }
+
+    @Test
+    public void testListRemoteSegmentsWithMinBaseOffset() throws Exception {
+        HDFSRemoteStorageManager rsm = new HDFSRemoteStorageManager();
+        rsm.configure(config);
+
+        TopicPartition tp = new TopicPartition("test", 1);
+        int segmentSize = 20;
+        for (int i = 0; i < 10; i++) {
+            LogSegment seg = LogUtils.createSegment(segmentSize * i, logDir, 4096, Time.SYSTEM);
+            appendRecords(seg, segmentSize * i, segmentSize);
+            seg.onBecomeInactiveSegment();
+            rsm.copyLogSegment(tp, seg);
+        }
+
+        int numSegments = 5;
+        List<RemoteLogSegmentInfo> remoteSegments = rsm.listRemoteSegments(tp, numSegments * segmentSize);
+        assertEquals(numSegments, remoteSegments.size());
+        for (int i = numSegments; i < 10; i++) {
+            RemoteLogSegmentInfo segment = remoteSegments.get(i - numSegments);
+            assertEquals(segmentSize * i, segment.baseOffset());
+            assertEquals(segmentSize * (i + 1) - 1, segment.endOffset());
+        }
+    }
 }


### PR DESCRIPTION
This commit adds a new variant of `listRemoteSegments` method to `RemoteStorageManager`, which has `minBaseOffset` parameter. This is useful for reducing listing time on the remote tier in some implementations (like S3).