### PR TITLE
Add TopicPartition to RemoteLogSegmentInfo

### DIFF
--- a/core/src/main/scala/kafka/log/remote/RemoteLogSegmentInfo.scala
+++ b/core/src/main/scala/kafka/log/remote/RemoteLogSegmentInfo.scala
@@ -16,7 +16,10 @@
  */
 package kafka.log.remote
 
+import org.apache.kafka.common.TopicPartition
+
 trait RemoteLogSegmentInfo {
+  def topicPartition: TopicPartition
   def baseOffset : Long
   def endOffset: Long
 }

--- a/remote-storage-managers/hdfs/src/main/java/org/apache/kafka/rsm/hdfs/HDFSRemoteLogSegmentInfo.java
+++ b/remote-storage-managers/hdfs/src/main/java/org/apache/kafka/rsm/hdfs/HDFSRemoteLogSegmentInfo.java
@@ -16,18 +16,27 @@
  */
 package org.apache.kafka.rsm.hdfs;
 
+import org.apache.kafka.common.TopicPartition;
+
 import kafka.log.remote.RemoteLogSegmentInfo;
 import org.apache.hadoop.fs.Path;
 
 public class HDFSRemoteLogSegmentInfo implements RemoteLogSegmentInfo {
+    private TopicPartition topicPartition;
     private long baseOffset;
     private long endOffset;
     private Path path;
 
-    HDFSRemoteLogSegmentInfo(long baseOffset, long endOffset, Path path) {
+    HDFSRemoteLogSegmentInfo(TopicPartition topicPartition, long baseOffset, long endOffset, Path path) {
+        this.topicPartition = topicPartition;
         this.baseOffset = baseOffset;
         this.endOffset = endOffset;
         this.path = path;
+    }
+
+    @Override
+    public TopicPartition topicPartition() {
+        return topicPartition;
     }
 
     @Override

--- a/remote-storage-managers/hdfs/src/main/java/org/apache/kafka/rsm/hdfs/HDFSRemoteStorageManager.java
+++ b/remote-storage-managers/hdfs/src/main/java/org/apache/kafka/rsm/hdfs/HDFSRemoteStorageManager.java
@@ -161,7 +161,8 @@ public class HDFSRemoteStorageManager implements RemoteStorageManager {
                     long baseOffset = Long.parseLong(m.group(1));
                     if (baseOffset >= minBaseOffset) {
                         long endOffset = Long.parseLong(m.group(2));
-                        HDFSRemoteLogSegmentInfo segment = new HDFSRemoteLogSegmentInfo(baseOffset, endOffset, file.getPath());
+                        HDFSRemoteLogSegmentInfo segment =
+                            new HDFSRemoteLogSegmentInfo(topicPartition, baseOffset, endOffset, file.getPath());
                         segments.add(segment);
                     }
                 } catch (NumberFormatException e) {

--- a/remote-storage-managers/hdfs/src/test/java/org/apache/kafka/rsm/hdfs/HDFSRemoteStorageManagerTest.java
+++ b/remote-storage-managers/hdfs/src/test/java/org/apache/kafka/rsm/hdfs/HDFSRemoteStorageManagerTest.java
@@ -340,6 +340,7 @@ public class HDFSRemoteStorageManagerTest {
         // remote segments list returned by RSM should be sorted by base offset
         List<RemoteLogSegmentInfo> remoteSegments = rsm.listRemoteSegments(tp);
         for (int i = 0; i < 20; i++) {
+            assertEquals(tp, remoteSegments.get(i).topicPartition());
             if (i % 2 == 0) {
                 assertEquals((i / 2) * 20, remoteSegments.get(i).baseOffset());
                 assertEquals((i / 2) * 20 + 19, remoteSegments.get(i).endOffset());
@@ -409,6 +410,7 @@ public class HDFSRemoteStorageManagerTest {
         assertEquals(numSegments, remoteSegments.size());
         for (int i = numSegments; i < 10; i++) {
             RemoteLogSegmentInfo segment = remoteSegments.get(i - numSegments);
+            assertEquals(tp, segment.topicPartition());
             assertEquals(segmentSize * i, segment.baseOffset());
             assertEquals(segmentSize * (i + 1) - 1, segment.endOffset());
         }


### PR DESCRIPTION
This commit adds `TopicPartition` to `RemoteLogSegmentInfo` and its implementations. This is needed because a remote segment can't be identified by the base and end offsets alone, topic-partition information is also needed.