### PR TITLE
Add topic-partition to RemoteStorageManager.read

### DIFF
--- a/core/src/main/scala/kafka/log/remote/RemoteLogManager.scala
+++ b/core/src/main/scala/kafka/log/remote/RemoteLogManager.scala
@@ -309,7 +309,7 @@ class RemoteLogManager(fetchLog: TopicPartition => Option[Log],
       .getOrElse(throw new OffsetOutOfRangeException(
         s"Received request for offset $offset for partition $tp, which does not exist in remote tier"))
 
-    val records = remoteStorageManager.read(entry, fetchInfo.maxBytes, offset, minOneMessage)
+    val records = remoteStorageManager.read(tp, entry, fetchInfo.maxBytes, offset, minOneMessage)
 
     FetchDataInfo(LogOffsetMetadata(offset), records)
   }

--- a/core/src/main/scala/kafka/log/remote/RemoteStorageManager.scala
+++ b/core/src/main/scala/kafka/log/remote/RemoteStorageManager.scala
@@ -119,6 +119,7 @@ trait RemoteStorageManager extends Configurable with AutoCloseable {
    *
    * Will read at least one batch, if the 1st batch size is larger than maxBytes.
    *
+   * @param topicPartition      The topic and partition to read from
    * @param remoteLogIndexEntry The first remoteLogIndexEntry that remoteLogIndexEntry.lastOffset >= startOffset
    * @param maxBytes            maximum bytes to fetch for the given entry
    * @param startOffset         initial offset to be read from the given rdi in remoteLogIndexEntry
@@ -126,7 +127,11 @@ trait RemoteStorageManager extends Configurable with AutoCloseable {
    * @return
    */
   @throws(classOf[IOException])
-  def read(remoteLogIndexEntry: RemoteLogIndexEntry, maxBytes: Int, startOffset: Long, minOneMessage: Boolean): Records
+  def read(topicPartition: TopicPartition,
+           remoteLogIndexEntry: RemoteLogIndexEntry,
+           maxBytes: Int,
+           startOffset: Long,
+           minOneMessage: Boolean): Records
 
   /**
    * stops all the threads and closes the instance.

--- a/core/src/test/scala/unit/kafka/log/remote/RemoteLogManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/remote/RemoteLogManagerTest.scala
@@ -206,7 +206,7 @@ class MockRemoteStorageManager extends RemoteStorageManager {
 
   override def deleteTopicPartition(topicPartition: TopicPartition): Boolean = true
 
-  override def read(remoteLogIndexEntry: RemoteLogIndexEntry, maxBytes: Int, startOffset: Long,
+  override def read(topicPartition: TopicPartition, remoteLogIndexEntry: RemoteLogIndexEntry, maxBytes: Int, startOffset: Long,
                     minOneMessage: Boolean): Records = MemoryRecords.EMPTY
 
   override def close(): Unit = {}

--- a/remote-storage-managers/hdfs/src/main/java/org/apache/kafka/rsm/hdfs/HDFSRemoteStorageManager.java
+++ b/remote-storage-managers/hdfs/src/main/java/org/apache/kafka/rsm/hdfs/HDFSRemoteStorageManager.java
@@ -256,7 +256,11 @@ public class HDFSRemoteStorageManager implements RemoteStorageManager {
      * Read remote log from startOffset.
      **/
     @Override
-    public Records read(RemoteLogIndexEntry remoteLogIndexEntry, int maxBytes, long startOffset, boolean minOneMessage) throws IOException {
+    public Records read(TopicPartition topicPartition,
+                        RemoteLogIndexEntry remoteLogIndexEntry,
+                        int maxBytes,
+                        long startOffset,
+                        boolean minOneMessage) throws IOException {
         if (startOffset > remoteLogIndexEntry.lastOffset())
             throw new IllegalArgumentException("startOffset > remoteLogIndexEntry.lastOffset()");
 

--- a/remote-storage-managers/hdfs/src/test/java/org/apache/kafka/rsm/hdfs/HDFSRemoteStorageManagerTest.java
+++ b/remote-storage-managers/hdfs/src/test/java/org/apache/kafka/rsm/hdfs/HDFSRemoteStorageManagerTest.java
@@ -146,7 +146,7 @@ public class HDFSRemoteStorageManagerTest {
         assertEquals(2, remoteSegments.size());
 
         indexEntries = rsm.getRemoteLogIndexEntries(remoteSegments.get(0));
-        Records records = rsm.read(indexEntries.get(0), 100000, 0, true);
+        Records records = rsm.read(tp, indexEntries.get(0), 100000, 0, true);
         int count = 0;
         for (Record r : records.records()) {
             assertFalse(r.hasKey());
@@ -155,7 +155,7 @@ public class HDFSRemoteStorageManagerTest {
         }
         assertEquals(200, count);
 
-        records = rsm.read(indexEntries.get(0), 100000, 200, true);
+        records = rsm.read(tp, indexEntries.get(0), 100000, 200, true);
         count = 0;
         for (Record r : records.records()) {
             assertFalse(r.hasKey());
@@ -164,7 +164,7 @@ public class HDFSRemoteStorageManagerTest {
         }
         assertEquals(100, count);
 
-        records = rsm.read(indexEntries.get(0), 100, 0, true);
+        records = rsm.read(tp, indexEntries.get(0), 100, 0, true);
         count = 0;
         for (Record r : records.records()) {
             assertFalse(r.hasKey());
@@ -193,7 +193,7 @@ public class HDFSRemoteStorageManagerTest {
         List<RemoteLogSegmentInfo> remoteSegments = rsm.listRemoteSegments(tp);
         List<RemoteLogIndexEntry> indexEntries = rsm.getRemoteLogIndexEntries(remoteSegments.get(0));
 
-        Records records = rsm.read(indexEntries.get(0), 100000, 0, true);
+        Records records = rsm.read(tp, indexEntries.get(0), 100000, 0, true);
         int count = 0;
         for (Record r : records.records()) {
             assertFalse(r.hasKey());
@@ -205,7 +205,7 @@ public class HDFSRemoteStorageManagerTest {
         rsm.deleteLogSegment(remoteSegments.get(0));
 
         assertThrows(IOException.class, () -> {
-            rsm.read(indexEntries.get(0), 100000, 0, true);
+            rsm.read(tp, indexEntries.get(0), 100000, 0, true);
         });
 
         assertThrows(IOException.class, () -> {


### PR DESCRIPTION
The rationale: in S3 implementation, there's a possibility to set up
different S3 buckets for different topics, so topic-partitions needs to
be known. It would be more clear to have it explicitly passed to `read`
instead of parsing RDI for it.