### PR TITLE
MINOR Fixed building indexes for the passive segments which are not y…

### DIFF
--- a/.arcconfig
+++ b/.arcconfig
@@ -1,3 +1,18 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 {
     "project_id": "kafka10",
     "conduit_uri": "https://code.uberinternal.com/",

--- a/clients/src/main/resources/common/message/FetchRequest.json
+++ b/clients/src/main/resources/common/message/FetchRequest.json
@@ -44,7 +44,7 @@
   // Version 10 indicates that we can use the ZStd compression algorithm, as
   // described in KIP-110.
   //
-  "validVersions": "0-11",
+  "validVersions": "0-12",
   "fields": [
     { "name": "ReplicaId", "type": "int32", "versions": "0+",
       "about": "The broker ID of the follower, of -1 if this request is from a consumer." },

--- a/clients/src/main/resources/common/message/FetchResponse.json
+++ b/clients/src/main/resources/common/message/FetchResponse.json
@@ -62,7 +62,7 @@
           "about": "The last stable offset (or LSO) of the partition. This is the last offset such that the state of all transactional records prior to this offset have been decided (ABORTED or COMMITTED)" },
         { "name": "LogStartOffset", "type": "int64", "versions": "5+", "default": "-1", "ignorable": true,
           "about": "The current log start offset." },
-        {"name":  "next_local_offset", "type": "int64", "versions": "12+", "default": "-1", "ignorable": true,
+        {"name":  "NextLocalOffset", "type": "int64", "versions": "12+", "default": "-1", "ignorable": true,
           "about":  "Next local offset available on leader when tiered storage is enabled for a topic."},
         { "name": "Aborted", "type": "[]AbortedTransaction", "versions": "4+", "nullableVersions": "4+", "ignorable": false,
           "about": "The aborted transactions.",  "fields": [

--- a/core/src/main/scala/kafka/log/AbstractIndex.scala
+++ b/core/src/main/scala/kafka/log/AbstractIndex.scala
@@ -201,16 +201,6 @@ abstract class AbstractIndex[K, V](_file: File, val baseOffset: Long,
   }
 
   /**
-   * Rename the file that backs this offset index
-   *
-   * @throws IOException if rename fails
-   */
-  def renameTo(f: File): Unit = {
-    try Utils.atomicMoveWithFallback(file.toPath, f.toPath)
-    finally file = f
-  }
-
-  /**
    * Flush the data in the index to disk
    */
   def flush(): Unit = {

--- a/core/src/main/scala/kafka/log/CleanableIndex.scala
+++ b/core/src/main/scala/kafka/log/CleanableIndex.scala
@@ -18,9 +18,19 @@ package kafka.log
 
 import java.io.{Closeable, File}
 
+import org.apache.kafka.common.utils.Utils
+
 abstract class CleanableIndex(@volatile var file: File) extends Closeable {
 
-  def renameTo(f: File)
+  /**
+   * Rename the file that backs this offset index
+   *
+   * @throws IOException if rename fails
+   */
+  def renameTo(toBeRenamedFile: File): Unit = {
+    try Utils.atomicMoveWithFallback(file.toPath, toBeRenamedFile.toPath)
+    finally file = toBeRenamedFile
+  }
 
   def deleteIfExists(): Boolean
 }

--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -309,8 +309,8 @@ class Log(@volatile var dir: File,
       s"log end offset $logEndOffset in ${time.milliseconds() - startMs} ms")
   }
 
-  def updateLogStartOffsetFromRemoteTier(lso: Long): Unit = {
-    logStartOffset = lso
+  def updateLogStartOffsetFromRemoteTier(remoteLso: Long): Unit = {
+    logStartOffset = if (remoteLso < 0) localLogStartOffset else remoteLso
   }
 
   def highWatermark: Long = highWatermarkMetadata.messageOffset

--- a/core/src/main/scala/kafka/log/LogManager.scala
+++ b/core/src/main/scala/kafka/log/LogManager.scala
@@ -625,7 +625,7 @@ class LogManager(logDirs: Seq[File],
     } {
       try {
         val logStartOffsets = partitionToLog.collect {
-          case (k, log) if log.logStartOffset > log.logSegments.head.baseOffset => k -> log.logStartOffset
+          case (k, log) if (remoteLogManagerConfig.remoteLogStorageEnable || log.logStartOffset > log.logSegments.head.baseOffset) => k -> log.logStartOffset
         }
         checkpoint.write(logStartOffsets)
       } catch {

--- a/core/src/main/scala/kafka/log/remote/RLMIndexer.scala
+++ b/core/src/main/scala/kafka/log/remote/RLMIndexer.scala
@@ -49,7 +49,7 @@ class RLMIndexer(rsm: RemoteStorageManager, logFetcher: TopicPartition => Option
    * @return the offset of the topic-partition that is already indexed if it has done earlier, else it returns -1.
    */
   def getOrLoadIndexOffset(tp: TopicPartition): Option[Long] = {
-    maybeLoadIndex(tp).startOffset
+    maybeLoadIndex(tp).lastOffset
   }
 
   def maybeLoadIndex(tp: TopicPartition): TopicPartitionRemoteIndex = {

--- a/core/src/main/scala/kafka/log/remote/RemoteLogIndex.scala
+++ b/core/src/main/scala/kafka/log/remote/RemoteLogIndex.scala
@@ -158,11 +158,6 @@ class RemoteLogIndex(_file: File, val startOffset: Long) extends CleanableIndex(
     channel
   }
 
-  def renameTo(renamedFile: File) = {
-    try Utils.atomicMoveWithFallback(file.toPath, renamedFile.toPath)
-    finally file = renamedFile
-  }
-
   /**
    */
   def reset(): Unit = {

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -376,9 +376,9 @@ class KafkaServer(val config: KafkaConfig, time: Time = Time.SYSTEM, threadNameP
         logManager.getLog(tp)
       }
 
-      def updateRemoteLogStartOffset(tp:TopicPartition, lso:Long) : Unit = {
+      def updateRemoteLogStartOffset(tp:TopicPartition, remoteLso:Long) : Unit = {
         logManager.getLog(tp).foreach(log => {
-          log.updateLogStartOffsetFromRemoteTier(lso)
+          log.updateLogStartOffsetFromRemoteTier(remoteLso)
         })
       }
       Some(new RemoteLogManager(fetchLog, updateRemoteLogStartOffset, remoteLogManagerConfig, time))

--- a/core/src/test/scala/unit/kafka/log/remote/TopicPartitionRemoteIndexTest.scala
+++ b/core/src/test/scala/unit/kafka/log/remote/TopicPartitionRemoteIndexTest.scala
@@ -35,19 +35,10 @@ class TopicPartitionRemoteIndexTest extends JUnitSuite with Logging {
   private val partition = new TopicPartition("topic", 0)
 
   @Test
-  def testExistingIndexes() : Unit = {
-    val dir = new File("/tmp/kafka-logs/drivers-0")
-    val topicPartitionRemoteIndex = TopicPartitionRemoteIndex.open(partition, dir)
-    val lastOffset = topicPartitionRemoteIndex.lastOffset
-    assert(lastOffset.get > 0)
-  }
-
-  @Test
-  def testAppendLookupIndexWithBase(): Unit = {
+  def testAppendLookupIndexWithBaseAndReopenIndex(): Unit = {
     val entriesCt = 10
     val offsetStep = 100
-//    val dir = TestUtils.tempDir()
-    val dir = new File("/tmp/kafka-logs/drivers-0")
+    val dir = TestUtils.tempDir()
     val topicPartitionRemoteIndex = TopicPartitionRemoteIndex.open(partition, dir)
 
     // check for baseOffset with 0
@@ -57,11 +48,11 @@ class TopicPartitionRemoteIndexTest extends JUnitSuite with Logging {
     doTestIndexes(entriesCt, offsetStep, 10000L, dir, topicPartitionRemoteIndex)
 
     // reopen the index and check whether offsets are defined.
-    val partitionRemoteIndex = TopicPartitionRemoteIndex.open(partition, dir)
+    val reopenedPartitionIndex = TopicPartitionRemoteIndex.open(partition, dir)
 
-    assertEquals(0L, partitionRemoteIndex.startOffset.get)
-    assertEquals(10000L, partitionRemoteIndex.lastBatchStartOffset.get)
-    assertEquals(10900L, partitionRemoteIndex.lastOffset.get)
+    assertEquals(0L, reopenedPartitionIndex.startOffset.get)
+    assertEquals(10000L, reopenedPartitionIndex.lastBatchStartOffset.get)
+    assertEquals(10902L, reopenedPartitionIndex.lastOffset.get)
   }
 
   @Test


### PR DESCRIPTION
MINOR Fixed building indexes for the passive segments which are not tet read.
- Fixed FetchRequest and FetchResponse jsons with right field names and versions.
- Fixed updating log-start-offset when remote storage is enabled.
- Fixed TopicPartitionRemoteIndexTest