### PR TITLE
RSM class loader

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -867,7 +867,6 @@ project(':core') {
     from(configurations.archives.artifacts.files) { into("libs/") }
     from(project.siteDocsTar) { into("site-docs/") }
     from(project(':tools').jar) { into("libs/") }
-    from(project(':remote-storage-managers:hdfs').jar) { into("libs/") }
     from(project(':tools').configurations.runtime) { into("libs/") }
     from(project(':connect:api').jar) { into("libs/") }
     from(project(':connect:api').configurations.runtime) { into("libs/") }
@@ -893,8 +892,8 @@ project(':core') {
     from(project(':streams:test-utils').configurations.runtime) { into("libs/") }
     from(project(':streams:examples').jar) { into("libs/") }
     from(project(':streams:examples').configurations.runtime) { into("libs/") }
-    from(project(':remote-storage-managers:hdfs').jar) { into("libs/") }
-    from(project(':remote-storage-managers:hdfs').configurations.runtime) { into("libs/") }
+    from(project(':remote-storage-managers:hdfs').jar) { into("remote-storage/hdfs/libs/") }
+    from(new File(project(':remote-storage-managers:hdfs').buildDir.toString(), "dependant-libs/")) { into("remote-storage/hdfs/libs/") }
     duplicatesStrategy 'exclude'
   }
 
@@ -1848,8 +1847,13 @@ project(':connect:basic-auth-extension') {
 project(':remote-storage-managers:hdfs') {
   archivesBaseName = "kafka-rsm-hdfs"
 
+  configurations {
+    localDeps
+  }
+
   dependencies {
-    compile group: 'org.apache.hadoop', name: 'hadoop-client', version: '3.1.2'
+    localDeps group: 'org.apache.hadoop', name: 'hadoop-client', version: '3.1.2'
+    compile configurations.localDeps
     compile project(':core')
 
     testCompile libs.junit
@@ -1865,10 +1869,15 @@ project(':remote-storage-managers:hdfs') {
   }
 
   tasks.create(name: "copyDependantLibs", type: Copy) {
-    from(configurations.runtime) {
+    from(configurations.localDeps - project(':core').configurations.runtime - project(':tools').configurations.runtime) {
       exclude('kafka-rsm-hdfs*')
     }
-    into "$buildDir/dependant-libs-${versions.scala}"
+    into "$buildDir/dependant-libs"
+    duplicatesStrategy 'exclude'
+  }
+
+  jar {
+    dependsOn copyDependantLibs
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -892,8 +892,8 @@ project(':core') {
     from(project(':streams:test-utils').configurations.runtime) { into("libs/") }
     from(project(':streams:examples').jar) { into("libs/") }
     from(project(':streams:examples').configurations.runtime) { into("libs/") }
-    from(project(':remote-storage-managers:hdfs').jar) { into("remote-storage/hdfs/libs/") }
-    from(new File(project(':remote-storage-managers:hdfs').buildDir.toString(), "dependant-libs/")) { into("remote-storage/hdfs/libs/") }
+    from(project(':remote-storage-managers:hdfs').jar) { into("external/hdfs/libs/") }
+    from(new File(project(':remote-storage-managers:hdfs').buildDir.toString(), "dependant-libs/")) { into("external/hdfs/libs/") }
     duplicatesStrategy 'exclude'
   }
 

--- a/clients/src/main/java/org/apache/kafka/common/utils/ChildFirstClassLoader.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/ChildFirstClassLoader.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.utils;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.NoSuchElementException;
+
+/**
+ * A class loader that looks for classes and resources in a specified class path first, before delegating to its parent
+ * class loader.
+ */
+public class ChildFirstClassLoader extends URLClassLoader {
+    /**
+     * @param classPath Class path string
+     * @param parent    The parent classloader. If the required class / resource cannot be found in the given classPath,
+     *                  this classloader will be used to find the class / resource.
+     */
+    public ChildFirstClassLoader(String classPath, ClassLoader parent) {
+        super(classpath2URLs(classPath), parent);
+    }
+
+    static private URL[] classpath2URLs(String classPath) {
+        ArrayList<URL> urls = new ArrayList<>();
+        for (String path : classPath.split(";")) {
+            if (path == null || path.trim().isEmpty())
+                continue;
+            File f = new File(path);
+
+            if (path.endsWith("/*")) {
+                try {
+                    File parent = new File(new File(f.getCanonicalPath()).getParent());
+                    if (parent.isDirectory()) {
+                        File[] files = parent.listFiles((dir, name) -> {
+                            String lower = name.toLowerCase();
+                            return lower.endsWith(".jar") || lower.endsWith(".zip");
+                        });
+                        for (File jarFile : files) {
+                            urls.add(jarFile.getCanonicalFile().toURI().toURL());
+                        }
+                    }
+                } catch (IOException e) {
+                }
+            } else if (f.exists()) {
+                try {
+                    urls.add(f.getCanonicalFile().toURI().toURL());
+                } catch (IOException e) {
+                }
+            }
+        }
+        return urls.toArray(new URL[0]);
+    }
+
+    @Override
+    protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+        synchronized (getClassLoadingLock(name)) {
+            Class<?> c = findLoadedClass(name);
+
+            if (c == null) {
+                try {
+                    c = findClass(name);
+                } catch (ClassNotFoundException e) {
+                    // try parent
+                    c = super.loadClass(name, resolve);
+                }
+            }
+
+            if (resolve)
+                resolveClass(c);
+
+            return c;
+        }
+    }
+
+    @Override
+    public URL getResource(String name) {
+        URL url = findResource(name);
+        if (url == null) {
+            // try parent
+            url = super.getResource(name);
+        }
+        return url;
+    }
+
+    @Override
+    public Enumeration<URL> getResources(String name) throws IOException {
+        Enumeration<URL> urls1 = findResources(name);
+        Enumeration<URL> urls2 = getParent() != null ? getParent().getResources(name) : null;
+
+        return new Enumeration<URL>() {
+            @Override
+            public boolean hasMoreElements() {
+                return (urls1 != null && urls1.hasMoreElements()) || (urls2 !=null && urls2.hasMoreElements());
+            }
+
+            @Override
+            public URL nextElement() {
+                if (urls1 != null && urls1.hasMoreElements())
+                    return urls1.nextElement();
+                if (urls2 != null && urls2.hasMoreElements())
+                    return urls2.nextElement();
+                throw new NoSuchElementException();
+            }
+        };
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/utils/ChildFirstClassLoader.java
+++ b/clients/src/main/java/org/apache/kafka/common/utils/ChildFirstClassLoader.java
@@ -29,6 +29,10 @@ import java.util.NoSuchElementException;
  * class loader.
  */
 public class ChildFirstClassLoader extends URLClassLoader {
+    static {
+        ClassLoader.registerAsParallelCapable();
+    }
+
     /**
      * @param classPath Class path string
      * @param parent    The parent classloader. If the required class / resource cannot be found in the given classPath,
@@ -40,7 +44,7 @@ public class ChildFirstClassLoader extends URLClassLoader {
 
     static private URL[] classpath2URLs(String classPath) {
         ArrayList<URL> urls = new ArrayList<>();
-        for (String path : classPath.split(";")) {
+        for (String path : classPath.split(File.pathSeparator)) {
             if (path == null || path.trim().isEmpty())
                 continue;
             File f = new File(path);
@@ -79,7 +83,7 @@ public class ChildFirstClassLoader extends URLClassLoader {
                     c = findClass(name);
                 } catch (ClassNotFoundException e) {
                     // try parent
-                    c = super.loadClass(name, resolve);
+                    c = super.loadClass(name, false);
                 }
             }
 

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -126,6 +126,7 @@ object Defaults {
   val MessageDownConversionEnable = true
   val RemoteLogStorageEnable = false
   val RemoteStorageManager = ""
+  val RemoteStorageManagerClassPath = ""
   val RemoteLogRetentionMinutes = 7 * 24 * 60L
   val RemoteLogRetentionBytes = 1024 * 1024 * 1024L
   val RemoteLogManagerThreadPoolSize = 10
@@ -363,6 +364,7 @@ object KafkaConfig {
   // Remote log storage config //
   val RemoteLogStorageEnableProp = "remote.log.storage.enable"
   val RemoteLogStorageManagerProp = "remote.log.storage.manager.class.name"
+  val RemoteLogStorageManagerClassPathProp = "remote.log.storage.manager.class.path"
   val RemoteLogRetentionMillisProp = "remote.log.retention.ms"
   val RemoteLogRetentionMinutesProp = "remote.log.retention.minutes"
   val RemoteLogRetentionBytesProp = "remote.log.retention.bytes"
@@ -689,6 +691,10 @@ object KafkaConfig {
   val LogMessageDownConversionEnableDoc = TopicConfig.MESSAGE_DOWNCONVERSION_ENABLE_DOC
   val RemoteLogStorageEnableDoc = "Whether to enable remote log storage or not."
   val RemoteStorageManagerDoc = "Fully qualified classname of RemoteLogStorageManager implementation."
+  val RemoteStorageManagerClassPathDoc = "Class path of the RemoteLogStorageManager implementation." +
+    "If specified, the RemoteLogStorageManager implementation and its dependent libraries will be loaded by a dedicated" +
+    "classloader which searches this class path before the Kafka broker class path. The syntax of this parameter is same" +
+    "with the standard Java class path string."
   val RemoteLogRetentionMillisDoc = "Remote log retention in milli seconds, after which remote log segment is deleted."
   val RemoteLogRetentionMinutesDoc = "Remote log retention in minutes, after which remote log segment is deleted."
   val RemoteLogRetentionBytesDoc = "Remote log size retention in bytes, after which remote log segment is deleted."
@@ -980,6 +986,7 @@ object KafkaConfig {
       .define(LogMessageDownConversionEnableProp, BOOLEAN, Defaults.MessageDownConversionEnable, LOW, LogMessageDownConversionEnableDoc)
       .define(RemoteLogStorageEnableProp, BOOLEAN, Defaults.RemoteLogStorageEnable, LOW, RemoteLogStorageEnableDoc)
       .define(RemoteLogStorageManagerProp, STRING, Defaults.RemoteStorageManager, LOW, RemoteStorageManagerDoc)
+      .define(RemoteLogStorageManagerClassPathProp, STRING, Defaults.RemoteStorageManagerClassPath, LOW, RemoteStorageManagerClassPathDoc)
       .define(RemoteLogRetentionMillisProp, LONG, null, LOW, RemoteLogRetentionMillisDoc)
       .define(RemoteLogRetentionMinutesProp, LONG, Defaults.RemoteLogRetentionMinutes, LOW, RemoteLogRetentionMinutesDoc)
       .define(RemoteLogRetentionBytesProp, LONG, Defaults.RemoteLogRetentionBytes, LOW, RemoteLogRetentionBytesDoc)
@@ -1292,6 +1299,7 @@ class KafkaConfig(val props: java.util.Map[_, _], doLog: Boolean, dynamicConfigO
   /** Remote log storage config **/
   def remoteLogStorageEnable: Boolean = getBoolean(KafkaConfig.RemoteLogStorageEnableProp)
   def remoteLogStorageManager: String = getString(KafkaConfig.RemoteLogStorageManagerProp)
+  def remoteLogStorageManagerClassPath: String = getString(KafkaConfig.RemoteLogStorageManagerClassPathProp)
   def remoteLogRetentionBytes: Long = getLong(KafkaConfig.RemoteLogRetentionBytesProp)
   def remoteLogRetentionMillis: Long = {
     val millisInMinute = 60L * 1000L

--- a/core/src/test/scala/unit/kafka/log/remote/RemoteLogManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/remote/RemoteLogManagerTest.scala
@@ -49,7 +49,7 @@ class RemoteLogManagerTest {
 
   val rsmConfig: Map[String, Any] = Map(REMOTE_STORAGE_MANAGER_CONFIG_PREFIX + "url" -> "foo.url",
     REMOTE_STORAGE_MANAGER_CONFIG_PREFIX + "timout.ms" -> 1000L)
-  val rlmConfig = RemoteLogManagerConfig(remoteLogStorageEnable = true, "kafka.log.remote.MockRemoteStorageManager",
+  val rlmConfig = RemoteLogManagerConfig(remoteLogStorageEnable = true, "kafka.log.remote.MockRemoteStorageManager", "",
     1024, 60000, 2, 10, rsmConfig, 10, 30000)
 
   var logConfig: LogConfig = _

--- a/core/src/test/scala/unit/kafka/log/remote/RemoteLogReaderTest.scala
+++ b/core/src/test/scala/unit/kafka/log/remote/RemoteLogReaderTest.scala
@@ -154,7 +154,7 @@ object MockRemoteLogManager {
     REMOTE_STORAGE_MANAGER_CONFIG_PREFIX + "timout.ms" -> 1000L)
 
   def rlmConfig(threads: Int, taskQueueSize: Int): RemoteLogManagerConfig = {
-    RemoteLogManagerConfig(remoteLogStorageEnable = true, "kafka.log.remote.MockRemoteStorageManager",
+    RemoteLogManagerConfig(remoteLogStorageEnable = true, "kafka.log.remote.MockRemoteStorageManager", "",
       1024, 60000, threads, taskQueueSize, rsmConfig, Defaults.RemoteLogManagerThreadPoolSize, Defaults.RemoteLogManagerTaskIntervalMs)
   }
 }

--- a/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
@@ -763,6 +763,7 @@ class KafkaConfigTest {
 
         //remote log storage manager config
         case KafkaConfig.RemoteLogStorageManagerProp => // ignore string
+        case KafkaConfig.RemoteLogStorageManagerClassPathProp => // ignore
         case KafkaConfig.RemoteLogStorageEnableProp => assertPropertyInvalid(getBaseProperties(), name, "not_a_boolean", "0")
         case KafkaConfig.RemoteLogRetentionBytesProp => assertPropertyInvalid(getBaseProperties(), name, "not_a_number")
         case KafkaConfig.RemoteLogRetentionMillisProp=> assertPropertyInvalid(getBaseProperties(), name, "not_a_number")


### PR DESCRIPTION
Load RSM jars with a dedicated class loader to avoid 3rd-party library conflicts with Kafka core

Kafka core and HDFS / S3 clients are using different versions of some open source libraries. By loading RMS and its dependent jars with a dedicated "child first" class loader, we can avoid the potential conflicts