### PR TITLE
Set context class loader to RSM class loader when calling RSM methods

### DIFF
--- a/core/src/main/scala/kafka/log/remote/RemoteLogManager.scala
+++ b/core/src/main/scala/kafka/log/remote/RemoteLogManager.scala
@@ -118,13 +118,14 @@ class RemoteLogManager(fetchLog: TopicPartition => Option[Log],
 
     val rsm = rsmClassLoader.loadClass(rlmConfig.remoteLogStorageManagerClass)
       .getDeclaredConstructor().newInstance().asInstanceOf[RemoteStorageManager]
+    val rsmWrapper = new RemoteStorageManagerWrapper(rsm, rsmClassLoader)
 
     val rsmProps = new util.HashMap[String, Any]()
     rlmConfig.remoteStorageConfig.foreach { case (k, v) => rsmProps.put(k, v) }
     rsmProps.put(KafkaConfig.RemoteLogRetentionMillisProp, rlmConfig.remoteLogRetentionMillis)
     rsmProps.put(KafkaConfig.RemoteLogRetentionBytesProp, rlmConfig.remoteLogRetentionBytes)
-    rsm.configure(rsmProps)
-    rsm
+    rsmWrapper.configure(rsmProps)
+    rsmWrapper
   }
 
   private val remoteStorageManager: RemoteStorageManager = createRemoteStorageManager()

--- a/core/src/main/scala/kafka/log/remote/RemoteStorageManagerWrapper.scala
+++ b/core/src/main/scala/kafka/log/remote/RemoteStorageManagerWrapper.scala
@@ -1,0 +1,76 @@
+package kafka.log.remote
+import java.io.IOException
+import java.util
+
+import kafka.log.LogSegment
+import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.record.Records
+
+/**
+ * A wrapper class of RemoteStorageManager that sets the context class loader when calling RSM methods
+ */
+class RemoteStorageManagerWrapper(val rsm: RemoteStorageManager, val rsmClassLoader: ClassLoader) extends RemoteStorageManager {
+
+  def withClassLoader[T](fun: => T): T = {
+    val originalClassLoader = Thread.currentThread.getContextClassLoader
+    Thread.currentThread.setContextClassLoader(rsmClassLoader)
+    try {
+      fun
+    } finally {
+      Thread.currentThread.setContextClassLoader(originalClassLoader)
+    }
+  }
+
+  @throws(classOf[IOException])
+  override def earliestLogOffset(tp: TopicPartition): Long = {
+    withClassLoader { rsm.earliestLogOffset(tp) }
+  }
+
+  @throws(classOf[IOException])
+  override def copyLogSegment(topicPartition: TopicPartition, logSegment: LogSegment, leaderEpoch: Int): util.List[RemoteLogIndexEntry] = {
+    withClassLoader { rsm.copyLogSegment(topicPartition, logSegment, leaderEpoch) }
+  }
+
+  @throws(classOf[IOException])
+  override def listRemoteSegments(topicPartition: TopicPartition): util.List[RemoteLogSegmentInfo] = {
+    withClassLoader { rsm.listRemoteSegments(topicPartition) }
+  }
+
+  @throws(classOf[IOException])
+  override def listRemoteSegments(topicPartition: TopicPartition, minBaseOffset: Long): util.List[RemoteLogSegmentInfo] = {
+    withClassLoader { rsm.listRemoteSegments(topicPartition, minBaseOffset) }
+  }
+
+  @throws(classOf[IOException])
+  override def getRemoteLogIndexEntries(remoteLogSegment: RemoteLogSegmentInfo): util.List[RemoteLogIndexEntry] = {
+    withClassLoader { rsm.getRemoteLogIndexEntries(remoteLogSegment) }
+  }
+
+  @throws(classOf[IOException])
+  override def deleteLogSegment(remoteLogSegmentInfo: RemoteLogSegmentInfo): Boolean = {
+    withClassLoader { rsm.deleteLogSegment(remoteLogSegmentInfo) }
+  }
+
+  @throws(classOf[IOException])
+  override def deleteTopicPartition(topicPartition: TopicPartition): Boolean = {
+    withClassLoader { rsm.deleteTopicPartition(topicPartition) }
+  }
+
+  @throws(classOf[IOException])
+  override def cleanupLogUntil(topicPartition: TopicPartition, cleanUpTillMs: Long): Long = {
+    withClassLoader { rsm.cleanupLogUntil(topicPartition, cleanUpTillMs) }
+  }
+
+  @throws(classOf[IOException])
+  override def read(remoteLogIndexEntry: RemoteLogIndexEntry, maxBytes: Int, startOffset: Long, minOneMessage: Boolean): Records = {
+    withClassLoader { rsm.read(remoteLogIndexEntry, maxBytes, startOffset, minOneMessage) }
+  }
+
+  override def close(): Unit = {
+    withClassLoader { rsm.close() }
+  }
+
+  override def configure(configs: util.Map[String, _]): Unit = {
+    withClassLoader { rsm.configure(configs) }
+  }
+}


### PR DESCRIPTION
Hadoop sometimes uses context class loader rather than the caller class' class loader to load some classes. We have to set the context class loader to RSM class loader when calling rsm methods