### PR TITLE
offset and timestamp lookup for remote data

### DIFF
--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -1653,15 +1653,13 @@ class Log(@volatile var dir: File,
         val remoteOffset = remoteLogManager.get.findOffsetByTimestamp(topicPartition, targetTimestamp, logStartOffset)
 
         if (localOffset.isEmpty)
-          return remoteOffset
-
-        if (remoteOffset.isEmpty)
-          return localOffset
-
-        if (localOffset.get.offset <= remoteOffset.get.offset)
-          return localOffset
-
-        remoteOffset
+          remoteOffset
+        else if (remoteOffset.isEmpty)
+          localOffset
+        else if (localOffset.get.offset <= remoteOffset.get.offset)
+          localOffset
+        else
+          remoteOffset
       } else {
         targetSeg.flatMap(_.findOffsetByTimestamp(targetTimestamp, logStartOffset))
       }

--- a/core/src/main/scala/kafka/log/remote/RLMIndexer.scala
+++ b/core/src/main/scala/kafka/log/remote/RLMIndexer.scala
@@ -55,7 +55,7 @@ class RLMIndexer(rsm: RemoteStorageManager, logFetcher: TopicPartition => Option
   }
 
   def maybeLoadIndex(tp: TopicPartition): Option[TopicPartitionRemoteIndex] = {
-    Option(remoteIndexes.computeIfAbsent(tp, new Function[TopicPartition, TopicPartitionRemoteIndex]() {
+    Some(remoteIndexes.computeIfAbsent(tp, new Function[TopicPartition, TopicPartitionRemoteIndex]() {
       override def apply(tp: TopicPartition): TopicPartitionRemoteIndex = {
         val log = logFetcher(tp).getOrElse(
           throw new RuntimeException("This broker is not a leader or a a follower for the given topic partition " + tp))

--- a/core/src/main/scala/kafka/log/remote/RemoteLogIndexEntry.scala
+++ b/core/src/main/scala/kafka/log/remote/RemoteLogIndexEntry.scala
@@ -176,6 +176,9 @@ object RemoteLogIndexEntry extends Logging {
 
   def parseEntry(ch: FileChannel, position: Long): Option[RemoteLogIndexEntry] = {
     val magicBuffer = ByteBuffer.allocate(2)
+    // The last 8 bytes of remote log index file is the "last offset" rather than a regular index entry
+    if (position + 8 >= ch.size)
+      return None
     val readCt = ch.read(magicBuffer, position)
     if (readCt > 0) {
       magicBuffer.flip()

--- a/core/src/main/scala/kafka/log/remote/RemoteLogManager.scala
+++ b/core/src/main/scala/kafka/log/remote/RemoteLogManager.scala
@@ -29,6 +29,7 @@ import kafka.server.{Defaults, FetchDataInfo, KafkaConfig, LogOffsetMetadata, Re
 import kafka.utils.Logging
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.errors.OffsetOutOfRangeException
+import org.apache.kafka.common.record.FileRecords.TimestampAndOffset
 import org.apache.kafka.common.requests.FetchRequest.PartitionData
 import org.apache.kafka.common.utils.{ChildFirstClassLoader, KafkaThread, Time, Utils}
 
@@ -110,7 +111,7 @@ class RemoteLogManager(fetchLog: TopicPartition => Option[Log],
     val classPath = rlmConfig.remoteLogStorageManagerClassPath
     val rsmClassLoader = {
       if (classPath != null && !classPath.trim.isEmpty) {
-        new ChildFirstClassLoader(rlmConfig.remoteLogStorageManagerClassPath, RemoteLogManager.getClass.getClassLoader) //TODO: YING
+        new ChildFirstClassLoader(rlmConfig.remoteLogStorageManagerClassPath, RemoteLogManager.getClass.getClassLoader)
       } else {
         RemoteLogManager.getClass.getClassLoader
       }
@@ -312,14 +313,17 @@ class RemoteLogManager(fetchLog: TopicPartition => Option[Log],
         debug(s"Cleaning remote log indexes of partition $topicPartition till remoteLogStartOffset:$remoteLogStartOffset")
 
         // remove all indexes earlier to lso and rename them with a suffix of [Log.DeletedFileSuffix].
-        val cleanedUpIndexes = rlmIndexer.maybeLoadIndex(topicPartition).cleanupIndexesUntil(remoteLogStartOffset)
-        if (!cleanedUpIndexes.isEmpty) {
-          info(s"Deleting remote log indexes of partition $topicPartition till remoteLogStartOffset:$remoteLogStartOffset")
+        val index = rlmIndexer.maybeLoadIndex(topicPartition)
+        if (index.isDefined) {
+          val cleanedUpIndexes = index.get.cleanupIndexesUntil(remoteLogStartOffset)
+          if (!cleanedUpIndexes.isEmpty) {
+            info(s"Deleting remote log indexes of partition $topicPartition till remoteLogStartOffset:$remoteLogStartOffset")
 
-          // deleting files in the current thread for now. These can be scheduled in a separate thread pool as it is more of
-          // a cleanup activity. If the broker shutsdown in the middle of this activity, restart will delete all these files
-          // as part of deleting files with a suffix of [Log.DeletedFileSuffix]
-          cleanedUpIndexes.foreach { x => x.deleteIfExists() }
+            // deleting files in the current thread for now. These can be scheduled in a separate thread pool as it is more of
+            // a cleanup activity. If the broker shutsdown in the middle of this activity, restart will delete all these files
+            // as part of deleting files with a suffix of [Log.DeletedFileSuffix]
+            cleanedUpIndexes.foreach { x => x.deleteIfExists() }
+          }
         }
       }
 
@@ -372,6 +376,32 @@ class RemoteLogManager(fetchLog: TopicPartition => Option[Log],
     val records = remoteStorageManager.read(entry, fetchInfo.maxBytes, offset, minOneMessage)
 
     FetchDataInfo(LogOffsetMetadata(offset), records)
+  }
+
+  /**
+   * Search the message offset in the remote storage based on timestamp and offset.
+   *
+   * This method returns an option of TimestampOffset. The returned value is determined using the following ordered list of rules:
+   *
+   * - If there is no messages in the remote storage, return None
+   * - If all the messages in the remote storage have smaller offsets, return None
+   * - If all the messages in the remote storage have smaller timestamps, return None
+   * - If all the messages in the remote storage have larger timestamps, or no message in the remote storage has a timestamp
+   *   the returned the offset will be max(the earliest offset in the remote storage, startingOffset) and the timestamp will
+   *   be Message.NoTimestamp.
+   * - Otherwise, return an option of TimestampOffset. The offset is the offset of the first message whose timestamp
+   *   is greater than or equals to the target timestamp and whose offset is greater than or equals to the startingOffset.
+   *
+   * @param timestamp The timestamp to search for.
+   * @param startingOffset The starting offset to search.
+   * @return the timestamp and offset of the first message that meets the requirements. None will be returned if there is no such message.
+   */
+  def findOffsetByTimestamp(tp: TopicPartition, timestamp: Long, startingOffset: Long): Option[TimestampAndOffset] = {
+    val entry = rlmIndexer.lookupEntryForTimestamp(tp, timestamp, startingOffset)
+    if (entry.isEmpty)
+      return None
+
+    Option(remoteStorageManager.findOffsetByTimestamp(entry.get, timestamp, startingOffset))
   }
 
   /**

--- a/core/src/main/scala/kafka/log/remote/RemoteStorageManager.scala
+++ b/core/src/main/scala/kafka/log/remote/RemoteStorageManager.scala
@@ -21,6 +21,7 @@ import java.io.IOException
 
 import kafka.log.LogSegment
 import org.apache.kafka.common.annotation.InterfaceStability
+import org.apache.kafka.common.record.FileRecords.TimestampAndOffset
 import org.apache.kafka.common.record.Records
 import org.apache.kafka.common.{Configurable, TopicPartition}
 
@@ -130,6 +131,21 @@ trait RemoteStorageManager extends Configurable with AutoCloseable {
    */
   @throws(classOf[IOException])
   def read(remoteLogIndexEntry: RemoteLogIndexEntry, maxBytes: Int, startOffset: Long, minOneMessage: Boolean): Records
+
+
+  /**
+   * Search forward for the first message that meets the following requirements:
+   * - Message's timestamp is greater than or equals to the targetTimestamp.
+   * - Message's offset is greater than or equals to the startingOffset.
+   *
+   * @param targetTimestamp The timestamp to search for.
+   * @param startingOffset  The starting offset to search.
+   * @return The timestamp and offset of the message found. Null if no message is found.
+   */
+  @throws(classOf[IOException])
+  def findOffsetByTimestamp(remoteLogIndexEntry: RemoteLogIndexEntry,
+                            targetTimestamp: Long,
+                            startingOffset: Long): TimestampAndOffset
 
   /**
    * Release any system resources used by this instance.

--- a/core/src/main/scala/kafka/log/remote/RemoteStorageManagerWrapper.scala
+++ b/core/src/main/scala/kafka/log/remote/RemoteStorageManagerWrapper.scala
@@ -21,6 +21,7 @@ import java.util
 
 import kafka.log.LogSegment
 import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.record.FileRecords.TimestampAndOffset
 import org.apache.kafka.common.record.Records
 
 /**
@@ -81,6 +82,13 @@ class RemoteStorageManagerWrapper(val rsm: RemoteStorageManager, val rsmClassLoa
   @throws(classOf[IOException])
   override def read(remoteLogIndexEntry: RemoteLogIndexEntry, maxBytes: Int, startOffset: Long, minOneMessage: Boolean): Records = {
     withClassLoader { rsm.read(remoteLogIndexEntry, maxBytes, startOffset, minOneMessage) }
+  }
+
+  @throws(classOf[IOException])
+  override def findOffsetByTimestamp(remoteLogIndexEntry: RemoteLogIndexEntry,
+                                     targetTimestamp: Long,
+                                     startingOffset: Long): TimestampAndOffset = {
+    withClassLoader { rsm.findOffsetByTimestamp(remoteLogIndexEntry, targetTimestamp, startingOffset) }
   }
 
   override def close(): Unit = {

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -845,7 +845,7 @@ class ReplicaManager(val config: KafkaConfig,
                               currentLeaderEpoch: Optional[Integer],
                               fetchOnlyFromLeader: Boolean): Option[TimestampAndOffset] = {
     val partition = getPartitionOrException(topicPartition, expectLeader = fetchOnlyFromLeader)
-    partition.fetchOffsetForTimestamp(timestamp, isolationLevel, currentLeaderEpoch, fetchOnlyFromLeader)
+    partition.fetchOffsetForTimestamp(timestamp, isolationLevel, currentLeaderEpoch, fetchOnlyFromLeader, remoteLogManager)
   }
 
   def legacyFetchOffsetsForTimestamp(topicPartition: TopicPartition,
@@ -1125,7 +1125,6 @@ class ReplicaManager(val config: KafkaConfig,
           // If it is from a follower then send the offset metadata but not the records data as that can be fetched
           // from the remote store.
           if (remoteLogManager.isDefined && log != null && !log.config.compact && !Request.isValidBrokerId(replicaId)) {
-            val rlm = remoteLogManager.get
             val highWatermark = log.highWatermark
             val leaderLogStartOffset = log.logStartOffset
             val leaderLogEndOffset = log.logEndOffset

--- a/core/src/test/scala/unit/kafka/log/remote/RemoteLogIndexTest.scala
+++ b/core/src/test/scala/unit/kafka/log/remote/RemoteLogIndexTest.scala
@@ -80,15 +80,15 @@ object RemoteLogIndexTest {
     val rdi = "rdi://foo/bar/" + System.currentTimeMillis()
     val rdiBytes = rdi.getBytes
     var firstOffset = baseOffset
-    var firstTimestamp: Long = baseOffset + 10L
+    var firstTimestamp: Long = baseOffset * 1000L
     for (i <- 1 to numEntries) {
-      val lastOffset = firstOffset + 2
-      val lastTimestamp = firstTimestamp + 1
+      val lastOffset = firstOffset + offsetStep - 1
+      val lastTimestamp = lastOffset * 1000L
       val dataLength = Math.abs(new Random().nextInt())
       val entry: RemoteLogIndexEntry = RemoteLogIndexEntry(firstOffset, lastOffset, firstTimestamp, lastTimestamp,
         dataLength, rdiBytes)
       firstOffset += offsetStep
-      firstTimestamp += 1
+      firstTimestamp = firstOffset * 1000L
 
       entries += entry
     }

--- a/core/src/test/scala/unit/kafka/log/remote/RemoteLogManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/remote/RemoteLogManagerTest.scala
@@ -210,6 +210,9 @@ class MockRemoteStorageManager extends RemoteStorageManager {
   override def read(remoteLogIndexEntry: RemoteLogIndexEntry, maxBytes: Int, startOffset: Long,
                     minOneMessage: Boolean): Records = MemoryRecords.EMPTY
 
+  override def findOffsetByTimestamp(remoteLogIndexEntry: RemoteLogIndexEntry,
+                                     targetTimestamp: Long, startingOffset: Long): FileRecords.TimestampAndOffset = null
+
   override def close(): Unit = {}
 
   override def configure(configs: util.Map[String, _]): Unit = {


### PR DESCRIPTION
1. Support remote message look up in LIST_OFFSETS API
2. Rebuild the last remote index segment after broker restart, to avoid corrupted files in unclean shut down
3. Fix offset lookup for remote messages
4. Fix timestamp index of remote messages 