### PR TITLE
MINOR Refactored `deleteLogSegment` API to return void and always throw RemoteStorageException if the operation is failed.

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/log/remote/storage/RemoteStorageManager.java
+++ b/clients/src/main/java/org/apache/kafka/common/log/remote/storage/RemoteStorageManager.java
@@ -88,13 +88,16 @@ public interface RemoteStorageManager extends Configurable, Closeable {
     InputStream fetchTimestampIndex(RemoteLogSegmentMetadata remoteLogSegmentMetadata) throws RemoteStorageException;
 
     /**
-     * Deletes the remote log segment for the given remoteLogSegmentId. Returns true if the deletion is successful.
+     * Deletes the remote log segment for the given remoteLogSegmentMetadata. Deletion is considered as successful if
+     * this call returns successfully without any exceptions. It will throw {@link RemoteStorageException} if there are
+     * any errors in deleting the file.
+     *
      * Broker pushes an event to __delete_failed_remote_log_segments topic for failed segment deletions so that users
      * can do the cleanup later.
      *
      * @param remoteLogSegmentMetadata
-     * @return
      * @throws IOException
      */
-    boolean deleteLogSegment(RemoteLogSegmentMetadata remoteLogSegmentMetadata) throws RemoteStorageException;
+    void deleteLogSegment(RemoteLogSegmentMetadata remoteLogSegmentMetadata) throws RemoteStorageException;
+
 }

--- a/clients/src/test/java/org/apache/kafka/common/log/remote/storage/LocalRemoteStorageManager.java
+++ b/clients/src/test/java/org/apache/kafka/common/log/remote/storage/LocalRemoteStorageManager.java
@@ -197,13 +197,16 @@ public final class LocalRemoteStorageManager implements RemoteStorageManager  {
     }
 
     @Override
-    public boolean deleteLogSegment(final RemoteLogSegmentMetadata metadata) throws RemoteStorageException {
-        return wrap(() -> {
+    public void deleteLogSegment(final RemoteLogSegmentMetadata metadata) throws RemoteStorageException {
+        wrap(() -> {
             if (deleteEnabled) {
                 final RemoteLogSegmentFiles remote = new RemoteLogSegmentFiles(metadata.remoteLogSegmentId(), true);
-                return remote.deleteAll();
+                if(!remote.deleteAll()) {
+                    throw new RemoteStorageException("Failed to delete remote log segment with id:" +
+                            metadata.remoteLogSegmentId());
+                }
             }
-            return true;
+            return null;
         });
     }
 

--- a/core/src/main/scala/kafka/log/remote/ClassLoaderAwareRemoteStorageManager.scala
+++ b/core/src/main/scala/kafka/log/remote/ClassLoaderAwareRemoteStorageManager.scala
@@ -78,7 +78,7 @@ class ClassLoaderAwareRemoteStorageManager(val rsm: RemoteStorageManager,
     }
   }
 
-  override def deleteLogSegment(remoteLogSegmentMetadata: RemoteLogSegmentMetadata): Boolean = {
+  override def deleteLogSegment(remoteLogSegmentMetadata: RemoteLogSegmentMetadata): Unit = {
     withClassLoader {
       rsm.deleteLogSegment(remoteLogSegmentMetadata)
     }

--- a/core/src/test/scala/unit/kafka/log/remote/RemoteLogManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/remote/RemoteLogManagerTest.scala
@@ -222,5 +222,5 @@ class MockRemoteStorageManager extends RemoteStorageManager {
   override def fetchTimestampIndex(remoteLogSegmentMetadata: RemoteLogSegmentMetadata): InputStream = new ByteArrayInputStream(
     Array.emptyByteArray)
 
-  override def deleteLogSegment(remoteLogSegmentMetadata: RemoteLogSegmentMetadata): Boolean = true
+  override def deleteLogSegment(remoteLogSegmentMetadata: RemoteLogSegmentMetadata): Unit = true
 }

--- a/remote-storage-managers/hdfs/src/main/java/org/apache/kafka/rsm/hdfs/HDFSRemoteStorageManager.java
+++ b/remote-storage-managers/hdfs/src/main/java/org/apache/kafka/rsm/hdfs/HDFSRemoteStorageManager.java
@@ -36,7 +36,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.util.Map;
-import java.util.Optional;
 
 public class HDFSRemoteStorageManager implements RemoteStorageManager {
 
@@ -115,14 +114,20 @@ public class HDFSRemoteStorageManager implements RemoteStorageManager {
     }
 
     @Override
-    public boolean deleteLogSegment(RemoteLogSegmentMetadata remoteLogSegmentMetadata) throws RemoteStorageException {
+    public void deleteLogSegment(RemoteLogSegmentMetadata remoteLogSegmentMetadata) throws RemoteStorageException {
+        boolean delete;
         try {
             String path = getSegmentRemoteDir(remoteLogSegmentMetadata.remoteLogSegmentId());
 
-            FileSystem fs = getFS();
-            return fs.delete(new Path(path), true);
+            delete = getFS().delete(new Path(path), true);
         } catch (Exception e) {
-            throw new RemoteStorageException("Failed to delete remote log segment", e);
+            throw new RemoteStorageException( "Failed to delete remote log segment with id:" +
+                    remoteLogSegmentMetadata.remoteLogSegmentId(), e);
+        }
+
+        if(!delete) {
+            throw new RemoteStorageException("Failed to delete remote log segment with id:" +
+                    remoteLogSegmentMetadata.remoteLogSegmentId());
         }
     }
 


### PR DESCRIPTION
- Refactored `deleteLogSegment` API to return void and always throw RemoteStorageException if the operation is failed.