### PR TITLE
Fixed local and effective logStartOffset updation when segments are deleted locally but not in the remote tiered storage.

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/log/remote/storage/ClassLoaderAwareRemoteLogMetadataManager.java
+++ b/clients/src/main/java/org/apache/kafka/common/log/remote/storage/ClassLoaderAwareRemoteLogMetadataManager.java
@@ -87,7 +87,8 @@ public class ClassLoaderAwareRemoteLogMetadataManager implements RemoteLogMetada
             return delegate.highestLogOffset(tp);
         } finally {
             Thread.currentThread().setContextClassLoader(originalClassLoader);
-        }    }
+        }
+    }
 
     @Override
     public void deleteRemoteLogSegmentMetadata(RemoteLogSegmentId remoteLogSegmentId) throws IOException {

--- a/clients/src/test/java/org/apache/kafka/common/log/remote/storage/LocalRemoteStorageManagerTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/log/remote/storage/LocalRemoteStorageManagerTest.java
@@ -24,9 +24,6 @@ import org.junit.Test;
 import org.junit.rules.TestName;
 
 import static java.lang.String.format;
-import static org.apache.kafka.common.log.remote.storage.LocalRemoteStorageManager.DELETE_ON_CLOSE_PROP;
-import static org.apache.kafka.common.log.remote.storage.LocalRemoteStorageManager.ENABLE_DELETE_API_PROP;
-import static org.apache.kafka.common.log.remote.storage.LocalRemoteStorageManager.STORAGE_ID_PROP;
 import static org.junit.Assert.assertThrows;
 
 import java.io.File;
@@ -56,8 +53,8 @@ public final class LocalRemoteStorageManagerTest {
         remoteStorageVerifier = new LocalRemoteStorageVerifier(remoteStorage, topicPartition);
 
         Map<String, Object> config = new HashMap<>();
-        config.put(STORAGE_ID_PROP, generateStorageId());
-        config.put(DELETE_ON_CLOSE_PROP, "true");
+        config.put(LocalRemoteStorageManager.STORAGE_ID_PROP, generateStorageId());
+        config.put(LocalRemoteStorageManager.STORAGE_ID_PROP, "true");
         config.putAll(extraConfig);
 
         remoteStorage.configure(config);
@@ -141,7 +138,7 @@ public final class LocalRemoteStorageManagerTest {
 
     @Test
     public void segmentsAreNotDeletedIfDeleteApiIsDisabled() throws RemoteStorageException {
-        init(Collections.singletonMap(ENABLE_DELETE_API_PROP, "false"));
+        init(Collections.singletonMap(LocalRemoteStorageManager.STORAGE_ID_PROP, "false"));
 
         final RemoteLogSegmentId id = newRemoteLogSegmentId();
         final LogSegmentData segment = localLogSegments.nextSegment();
@@ -158,7 +155,7 @@ public final class LocalRemoteStorageManagerTest {
         final RemoteLogSegmentMetadata metadata = newRemoteLogSegmentMetadata(newRemoteLogSegmentId());
 
         assertThrows(RemoteResourceNotFoundException.class,
-                () -> remoteStorage.fetchLogSegmentData(metadata, 0L, null));
+            () -> remoteStorage.fetchLogSegmentData(metadata, 0L, null));
         assertThrows(RemoteResourceNotFoundException.class, () -> remoteStorage.fetchOffsetIndex(metadata));
         assertThrows(RemoteResourceNotFoundException.class, () -> remoteStorage.fetchTimestampIndex(metadata));
     }

--- a/core/src/main/scala/kafka/log/remote/RemoteLogManager.scala
+++ b/core/src/main/scala/kafka/log/remote/RemoteLogManager.scala
@@ -368,9 +368,8 @@ class RemoteLogManager(fetchLog: TopicPartition => Option[Log],
     def handleExpiredRemoteLogSegments(): Unit = {
 
       def handleLogStartOffsetUpdate(topicPartition: TopicPartition, remoteLogStartOffset: Long): Unit = {
+        debug(s"Updating $topicPartition with remoteLogStartOffset: $remoteLogStartOffset")
         updateRemoteLogStartOffset(topicPartition, remoteLogStartOffset)
-        debug(s"Cleaning remote log indexes of partition $topicPartition till remoteLogStartOffset:" +
-          s"$remoteLogStartOffset")
       }
 
       try {
@@ -388,7 +387,7 @@ class RemoteLogManager(fetchLog: TopicPartition => Option[Log],
                   maxOffset = Math.max(m.endOffset(), maxOffset)
                 })
 
-              if(maxOffset == Long.MinValue) None else Some(maxOffset)
+              if(maxOffset == Long.MinValue) None else Some(maxOffset+1)
             }
           } else {
             val result = remoteLogMetadataManager.earliestLogOffset(tp)

--- a/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
@@ -460,6 +460,7 @@ class DefaultMessageFormatter extends MessageFormatter {
   var printKey = false
   var printValue = true
   var printTimestamp = false
+  var printOffset = false
   var keySeparator = "\t".getBytes(StandardCharsets.UTF_8)
   var lineSeparator = "\n".getBytes(StandardCharsets.UTF_8)
 
@@ -469,6 +470,8 @@ class DefaultMessageFormatter extends MessageFormatter {
   override def init(props: Properties): Unit = {
     if (props.containsKey("print.timestamp"))
       printTimestamp = props.getProperty("print.timestamp").trim.equalsIgnoreCase("true")
+    if(props.containsKey("print.offset"))
+      printOffset = props.getProperty("print.offset").trim.equalsIgnoreCase("true")
     if (props.containsKey("print.key"))
       printKey = props.getProperty("print.key").trim.equalsIgnoreCase("true")
     if (props.containsKey("print.value"))
@@ -517,6 +520,13 @@ class DefaultMessageFormatter extends MessageFormatter {
     }
 
     import consumerRecord._
+
+    def writeOffset = {
+      output.write(consumerRecord.offset().toString.getBytes)
+      output.write(":".getBytes())
+    }
+
+    writeOffset
 
     if (printTimestamp) {
       if (timestampType != TimestampType.NO_TIMESTAMP_TYPE)

--- a/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
+++ b/core/src/main/scala/kafka/tools/ConsoleConsumer.scala
@@ -522,8 +522,8 @@ class DefaultMessageFormatter extends MessageFormatter {
     import consumerRecord._
 
     def writeOffset = {
-      output.write(consumerRecord.offset().toString.getBytes)
-      output.write(":".getBytes())
+      output.write(consumerRecord.offset().toString.getBytes("UTF-8"))
+      output.write(":".getBytes("UTF-8"))
     }
 
     writeOffset


### PR DESCRIPTION
- Fixed local and effective logStartOffset updation when segments are deleted locally but not in the remote tiered storage.
- Added option in ConsoleConsumer.DefaultFormatter to print offsets and other checkstyle and spotbug fixes.