### PR TITLE
Added RLMM to consume only for leader/follower partitions that broker is hosted.

### DIFF
--- a/clients/src/test/java/org/apache/kafka/clients/ApiVersionsTest.java
+++ b/clients/src/test/java/org/apache/kafka/clients/ApiVersionsTest.java
@@ -21,6 +21,12 @@ import org.apache.kafka.common.record.RecordBatch;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.IntStream;
 
 public class ApiVersionsTest {
 
@@ -37,6 +43,19 @@ public class ApiVersionsTest {
 
         apiVersions.remove("1");
         assertEquals(RecordBatch.CURRENT_MAGIC_VALUE, apiVersions.maxUsableProduceMagic());
+    }
+
+    @Test
+    public void testConcMapsIter() {
+        Map<Integer, String> map = new ConcurrentHashMap<>();
+        IntStream.range(0, 10).forEach( x -> map.put(x, x+""));
+
+        for (Map.Entry<Integer, String> entry : map.entrySet()) {
+
+                map.remove(entry.getKey());
+
+        }
+        assertTrue(map.isEmpty());
     }
 
 }

--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -1283,7 +1283,6 @@ class Log(@volatile var dir: File,
       lock synchronized {
         checkIfMemoryMappedBufferClosed()
         if (newLogStartOffset > logStartOffset) {
-          info(s"Incrementing log start offset to $newLogStartOffset")
           localLogStartOffset = math.max(newLogStartOffset, localLogStartOffset)
 
           // it should always get updated  if tiered-storage is not enabled.
@@ -1291,6 +1290,9 @@ class Log(@volatile var dir: File,
             logStartOffset = newLogStartOffset
             leaderEpochCache.foreach(_.truncateFromStart(logStartOffset))
             maybeIncrementFirstUnstableOffset()
+            info(s"Incrementing log start offset to $logStartOffset")
+          } else {
+            info(s"Incrementing local log start offset to $localLogStartOffset")
           }
         }
       }

--- a/core/src/main/scala/kafka/log/remote/RemoteLogManager.scala
+++ b/core/src/main/scala/kafka/log/remote/RemoteLogManager.scala
@@ -245,6 +245,8 @@ class RemoteLogManager(fetchLog: TopicPartition => Option[Log],
               deleteRemoteLogSegment(t)
             }
           })
+
+          remoteLogMetadataManager.onStopPartitions(topicPartitions.asJava)
         } catch {
           case ex: Exception => error(s"Error occurred while deleting topic partition: $tp", ex)
         }

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -1044,20 +1044,16 @@ class KafkaApis(val requestChannel: RequestChannel,
         if (aliveBrokers.size < config.remoteLogMetadataTopicReplicationFactor) {
           error(s"Number of alive brokers '${aliveBrokers.size}' does not meet the required replication factor " +
             s"'${config.remoteLogMetadataTopicReplicationFactor}' for the offsets topic (configured via " +
-            s"'${
-              KafkaConfig.RemoteLogMetadataTopicReplicationFactorProp
-            }'). This error can be ignored if the cluster is starting up " +
-            s"and not all brokers are up yet.")
+            s"'${KafkaConfig.RemoteLogMetadataTopicReplicationFactorProp}'). This error can be ignored if the cluster " +
+            s"is starting up and not all brokers are up yet.")
           new MetadataResponse.TopicMetadata(Errors.COORDINATOR_NOT_AVAILABLE, topic, true,
             util.Collections.emptyList())
         } else {
-          //todo-tier extract these as props and pass them.
-          // enforce disabled unclean leader election, no compression types, and compact cleanup policy
           val props = new Properties()
+          // enforce unclean leader election as disabled
           props.put(LogConfig.UncleanLeaderElectionEnableProp, "false")
           props.put(LogConfig.MinInSyncReplicasProp, ((config.remoteLogMetadataTopicReplicationFactor/2) + 1).toString)
-          //set 1 year as the retention period for remote log metadata.
-          props.put(LogConfig.RetentionMsProp, (365 * 24 * 60 * 60 * 1000).toString)
+          props.put(LogConfig.RetentionMsProp, (config.remoteLogMetadataTopicRetentionMins * 60 * 1000).toString)
 
           createTopic(topic, config.remoteLogMetadataTopicPartitions, config.remoteLogMetadataTopicReplicationFactor, props)
         }

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -129,6 +129,7 @@ object Defaults {
   val RemoteLogMetadataManager = ""
   val RemoteLogMetadataTopicReplicationFactor = RLMMWithTopicStorage.DEFAULT_REMOTE_LOG_METADATA_TOPIC_REPLICATION_FACTOR
   val RemoteLogMetadataTopicPartitions = RLMMWithTopicStorage.DEFAULT_REMOTE_LOG_METADATA_TOPIC_PARTITIONS
+  val RemoteLogMetadataTopicRetentionMins = RLMMWithTopicStorage.DEFAULT_REMOTE_LOG_METADATA_TOPIC_RETENTION_MINS
   val RemoteLogMetadataManagerClassPath = ""
   val RemoteLogRetentionMinutes = 7 * 24 * 60L
   val RemoteLogRetentionBytes = 1024 * 1024 * 1024L
@@ -379,6 +380,7 @@ object KafkaConfig {
   val RemoteLogReaderMaxPendingTasksProp = "remote.log.reader.max.pending.tasks"
   val RemoteLogMetadataTopicReplicationFactorProp = RLMMWithTopicStorage.REMOTE_LOG_METADATA_TOPIC_REPLICATION_FACTOR_PROP
   val RemoteLogMetadataTopicPartitionsProp = RLMMWithTopicStorage.REMOTE_LOG_METADATA_TOPIC_PARTITIONS_PROP
+  val RemoteLogMetadataTopicRetentionMinsProp = RLMMWithTopicStorage.REMOTE_LOG_METADATA_TOPIC_RETENTION_MINS_PROP
 
   /** ********* Replication configuration ***********/
   val ControllerSocketTimeoutMsProp = "controller.socket.timeout.ms"
@@ -705,6 +707,7 @@ object KafkaConfig {
   val RemoteLogMetadataManagerDoc = "Fully qualified classname of RemoteLogMetadataManager implementation."
   val RemoteLogMetadataTopicReplicationFactorDoc = "Replication factor of remote log metadata Topic."
   val RemoteLogMetadataTopicPartitionsDoc = "The number of partitions for remote log metadata Topic."
+  val RemoteLogMetadataTopicRetentionMinsDoc = "Remote log metadata topic log retention in minutes."
   val RemoteLogMetadataManagerClassPathDoc = "Class path of the RemoteLogStorageManager implementation." +
     "If specified, the RemoteLogStorageManager implementation and its dependent libraries will be loaded by a dedicated" +
     "classloader which searches this class path before the Kafka broker class path. The syntax of this parameter is same" +
@@ -1005,6 +1008,7 @@ object KafkaConfig {
       .define(RemoteLogMetadataManagerProp, STRING, Defaults.RemoteLogMetadataManager, LOW, RemoteLogMetadataManagerDoc)
       .define(RemoteLogMetadataTopicReplicationFactorProp, INT, Defaults.RemoteLogMetadataTopicReplicationFactor, LOW, RemoteLogMetadataTopicReplicationFactorDoc)
       .define(RemoteLogMetadataTopicPartitionsProp, INT, Defaults.RemoteLogMetadataTopicPartitions, LOW, RemoteLogMetadataTopicPartitionsDoc)
+      .define(RemoteLogMetadataTopicRetentionMinsProp, INT, Defaults.RemoteLogMetadataTopicRetentionMins, LOW, RemoteLogMetadataTopicRetentionMinsDoc)
       .define(RemoteLogMetadataManagerClassPathProp, STRING, Defaults.RemoteLogMetadataManagerClassPath, LOW, RemoteLogMetadataManagerClassPathDoc)
       .define(RemoteLogRetentionMillisProp, LONG, null, LOW, RemoteLogRetentionMillisDoc)
       .define(RemoteLogRetentionMinutesProp, LONG, Defaults.RemoteLogRetentionMinutes, LOW, RemoteLogRetentionMinutesDoc)
@@ -1340,6 +1344,7 @@ class KafkaConfig(val props: java.util.Map[_, _], doLog: Boolean, dynamicConfigO
   def remoteLogManagerTaskIntervalMs: Long = getLong(KafkaConfig.RemoteLogManagerTaskIntervalMsProp)
   def remoteLogMetadataTopicReplicationFactor:Int = getInt(KafkaConfig.RemoteLogMetadataTopicReplicationFactorProp)
   def remoteLogMetadataTopicPartitions:Int = getInt(KafkaConfig.RemoteLogMetadataTopicPartitionsProp)
+  def remoteLogMetadataTopicRetentionMins:Int = getInt(KafkaConfig.RemoteLogMetadataTopicRetentionMinsProp)
 
   /** ********* Replication configuration ***********/
   val controllerSocketTimeoutMs: Int = getInt(KafkaConfig.ControllerSocketTimeoutMsProp)

--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -353,7 +353,6 @@ class KafkaServer(val config: KafkaConfig, time: Time = Time.SYSTEM, threadNameP
         isStartingUp.set(false)
         AppInfoParser.registerAppInfo(jmxPrefix, config.brokerId.toString, metrics, time.milliseconds())
 
-        // todo-tier start RLMM by saying broker is ready
         remoteLogManager.foreach(rlm => rlm.onServerStarted())
         info("started")
       }

--- a/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
+++ b/core/src/test/scala/unit/kafka/server/KafkaConfigTest.scala
@@ -768,6 +768,7 @@ class KafkaConfigTest {
         case KafkaConfig.RemoteLogMetadataManagerClassPathProp => // ignore string
         case KafkaConfig.RemoteLogMetadataTopicPartitionsProp => assertPropertyInvalid(getBaseProperties(), name, "not_a_number")
         case KafkaConfig.RemoteLogMetadataTopicReplicationFactorProp => assertPropertyInvalid(getBaseProperties(), name, "not_a_number")
+        case KafkaConfig.RemoteLogMetadataTopicRetentionMinsProp => assertPropertyInvalid(getBaseProperties(), name, "not_a_number")
         case KafkaConfig.RemoteLogStorageEnableProp => assertPropertyInvalid(getBaseProperties(), name, "not_a_boolean", "0")
         case KafkaConfig.RemoteLogRetentionBytesProp => assertPropertyInvalid(getBaseProperties(), name, "not_a_number")
         case KafkaConfig.RemoteLogRetentionMillisProp=> assertPropertyInvalid(getBaseProperties(), name, "not_a_number")


### PR DESCRIPTION
- Added RLMM to consume only for leader/follower partitions that broker is hosted.
- Removed FileChannel#transferFrom call and using Files.copy while fetching indexes from RSM to build index cache.
- Added config for retention policy for remote log metadata topic and other minor fixes.
- Added more logging in RLMMWithTopicStorage.

I will add more tests in subsequent PRs.
