### PR TITLE
Added serdes for the messages stored in remote log metadata topic with internal protocol schema.

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/log/remote/metadata/storage/CommittedLogMetadataStore.java
+++ b/clients/src/main/java/org/apache/kafka/common/log/remote/metadata/storage/CommittedLogMetadataStore.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.log.remote.metadata.storage;
+
+import org.apache.kafka.common.log.remote.storage.RemoteLogSegmentMetadata;
+import org.apache.kafka.common.utils.Utils;
+
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+class CommittedLogMetadataStore {
+    private final File metadataStoreFile;
+
+    CommittedLogMetadataStore(File metadataStoreFile) {
+        this.metadataStoreFile = metadataStoreFile;
+
+        if (!metadataStoreFile.exists()) {
+            try {
+                metadataStoreFile.createNewFile();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    public synchronized void write(Collection<RemoteLogSegmentMetadata> remoteLogSegmentMetadatas)
+            throws IOException {
+        File newMetadataStoreFile = new File(metadataStoreFile.getAbsolutePath() + ".new");
+        try (FileOutputStream fileOutputStream = new FileOutputStream(newMetadataStoreFile);
+             BufferedOutputStream bufferedOutputStream = new BufferedOutputStream(fileOutputStream);
+             RLSMSerDe.RLSMSerializer serializer = new RLSMSerDe.RLSMSerializer()) {
+
+            //write version
+            ByteBuffer versionBuffer = ByteBuffer.allocate(2);
+            versionBuffer.putShort((short) 0);
+            bufferedOutputStream.write(versionBuffer.array());
+
+            ByteBuffer lenBuffer = ByteBuffer.allocate(4);
+
+            // write each entry
+            for (RemoteLogSegmentMetadata remoteLogSegmentMetadata : remoteLogSegmentMetadatas) {
+                final byte[] serializedBytes = serializer.serialize(null, remoteLogSegmentMetadata, false);
+                // write length
+                lenBuffer.putInt(serializedBytes.length);
+                bufferedOutputStream.write(lenBuffer.array());
+                lenBuffer.flip();
+
+                //write data
+                bufferedOutputStream.write(serializedBytes);
+            }
+
+            fileOutputStream.getFD().sync();
+        }
+
+        Utils.atomicMoveWithFallback(newMetadataStoreFile.toPath(), metadataStoreFile.toPath());
+    }
+
+    @SuppressWarnings("unchecked")
+    public synchronized Collection<RemoteLogSegmentMetadata> read() throws IOException {
+
+        // checking for empty files.
+        if (metadataStoreFile.length() == 0) {
+            return Collections.emptyList();
+        }
+
+        try (FileInputStream fis = new FileInputStream(metadataStoreFile);
+             RLSMSerDe.RLSMDeserializer deserializer = new RLSMSerDe.RLSMDeserializer()) {
+
+            List<RemoteLogSegmentMetadata> result = new ArrayList<>();
+
+            // read version
+            ByteBuffer versionBytes = ByteBuffer.allocate(2);
+            fis.read(versionBytes.array());
+            short version = versionBytes.getShort();
+
+            ByteBuffer lenBuffer = ByteBuffer.allocate(4);
+
+            //read the length of each entry
+            while (fis.read(lenBuffer.array()) != -1) {
+                final int len = lenBuffer.getInt();
+                lenBuffer.flip();
+
+                //read the entry
+                byte[] data = new byte[len];
+                final int read = fis.read(data);
+                if (read != len) {
+                    throw new IOException("Invalid amount of data read, file may have been corrupted.");
+                }
+
+                final RemoteLogSegmentMetadata rlsm = deserializer.deserialize(null, version,
+                        ByteBuffer.wrap(data));
+                result.add(rlsm);
+            }
+
+            return result;
+        }
+    }
+
+}

--- a/clients/src/main/java/org/apache/kafka/common/log/remote/metadata/storage/CommittedOffsetsFile.java
+++ b/clients/src/main/java/org/apache/kafka/common/log/remote/metadata/storage/CommittedOffsetsFile.java
@@ -1,0 +1,64 @@
+package org.apache.kafka.common.log.remote.metadata.storage;
+
+import org.apache.kafka.common.utils.Utils;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+// There are similar implementations in core/streams about offset checkpoint file.
+// We can not reuse them as they exist in core and streams modules and we do not need to store topic name as it is
+// same. We do not want this class to be moved into core, better to keep this out in clients or a new module.
+class CommittedOffsetsFile {
+    private final File offsetsFile;
+
+    private static final Pattern MINIMUM_ONE_WHITESPACE = Pattern.compile("\\s+");
+
+    CommittedOffsetsFile(File offsetsFile) {
+        this.offsetsFile = offsetsFile;
+    }
+
+    public synchronized void write(Map<Integer, Long> committedOffsets) throws IOException {
+        File newOffsetsFile = new File(offsetsFile.getAbsolutePath() + ".new");
+
+        FileOutputStream fos = new FileOutputStream(newOffsetsFile);
+        try (final BufferedWriter writer = new BufferedWriter(
+                new OutputStreamWriter(fos, StandardCharsets.UTF_8))) {
+            for (Map.Entry<Integer, Long> entry : committedOffsets.entrySet()) {
+                writer.write(entry.getKey() + " " + entry.getValue());
+                writer.newLine();
+            }
+
+            writer.flush();
+            fos.getFD().sync();
+        }
+
+        Utils.atomicMoveWithFallback(newOffsetsFile.toPath(), offsetsFile.toPath());
+    }
+
+    public synchronized Map<Integer, Long> read() throws IOException {
+        Map<Integer, Long> partitionOffsets = new HashMap<>();
+        try (BufferedReader bufferedReader = Files.newBufferedReader(offsetsFile.toPath(),
+                StandardCharsets.UTF_8)) {
+            String line = null;
+            while ((line = bufferedReader.readLine()) != null) {
+                String[] strings = MINIMUM_ONE_WHITESPACE.split(line);
+                if (strings.length != 2) {
+                    throw new IOException("Invalid format in line: []" + line);
+                }
+                int partition = Integer.parseInt(strings[0]);
+                long offset = Long.parseLong(strings[1]);
+                partitionOffsets.put(partition, offset);
+            }
+        }
+        return partitionOffsets;
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/log/remote/metadata/storage/CommittedOffsetsFile.java
+++ b/clients/src/main/java/org/apache/kafka/common/log/remote/metadata/storage/CommittedOffsetsFile.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.kafka.common.log.remote.metadata.storage;
 
 import org.apache.kafka.common.utils.Utils;
@@ -14,9 +30,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Pattern;
 
-// There are similar implementations in core/streams about offset checkpoint file.
-// We can not reuse them as they exist in core and streams modules and we do not need to store topic name as it is
-// same. We do not want this class to be moved into core, better to keep this out in clients or a new module.
 class CommittedOffsetsFile {
     private final File offsetsFile;
 

--- a/clients/src/main/java/org/apache/kafka/common/log/remote/metadata/storage/ConsumerTask.java
+++ b/clients/src/main/java/org/apache/kafka/common/log/remote/metadata/storage/ConsumerTask.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.kafka.common.log.remote.metadata.storage;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -243,8 +259,7 @@ class ConsumerTask implements Runnable, Closeable {
     private TopicPartition buildTopicPartition(String key) {
         int index = key.lastIndexOf("-");
         if (index < 0) {
-            throw new IllegalArgumentException(
-                    "Given key is not of topic partition format like <topic>-<partition>.");
+            throw new IllegalArgumentException("Given key is not of topic partition format like <topic>-<partition>.");
         }
         String topic = key.substring(0, index);
         int partition = Integer.parseInt(key.substring(index + 1));

--- a/clients/src/main/java/org/apache/kafka/common/log/remote/metadata/storage/ConsumerTask.java
+++ b/clients/src/main/java/org/apache/kafka/common/log/remote/metadata/storage/ConsumerTask.java
@@ -1,0 +1,258 @@
+package org.apache.kafka.common.log.remote.metadata.storage;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.WakeupException;
+import org.apache.kafka.common.internals.Topic;
+import org.apache.kafka.common.log.remote.storage.RemoteLogSegmentMetadata;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+class ConsumerTask implements Runnable, Closeable {
+    private static final Logger log = LoggerFactory.getLogger(ConsumerTask.class);
+    private final KafkaConsumer<String, RemoteLogSegmentMetadata> consumer;
+    private final RemoteLogSegmentMetadataUpdater remoteLogSegmentMetadataUpdater;
+    private final CommittedOffsetsFile committedOffsetsFile;
+
+    private final Object lock = new Object();
+    private volatile Set<Integer> assignedMetaPartitions = Collections.emptySet();
+    private Set<TopicPartition> reassignedTopicPartitions;
+
+    private volatile boolean closed = false;
+    private volatile boolean reassign = false;
+
+    private Map<Integer, Long> targetEndOffsets = new ConcurrentHashMap<>();
+
+    // map of topic-partition vs committed offsets
+    private Map<Integer, Long> committedOffsets = new ConcurrentHashMap<>();
+
+    private static final String COMMITTED_OFFSETS_FILE_NAME = "_rlmm_committed_offsets";
+    private long lastSyncedTs = System.currentTimeMillis();
+
+    public ConsumerTask(KafkaConsumer<String, RemoteLogSegmentMetadata> consumer,
+                        String logDirStr,
+                        RemoteLogSegmentMetadataUpdater remoteLogSegmentMetadataUpdater) throws IOException {
+        this.consumer = consumer;
+        final File logDir = new File(logDirStr);
+        this.remoteLogSegmentMetadataUpdater = remoteLogSegmentMetadataUpdater;
+
+        if (!logDir.exists()) {
+            throw new IllegalArgumentException("log.dir [" + logDirStr + "] does not exist.");
+        }
+
+        // look whether the committed file exists or not.
+        File file = new File(logDir, COMMITTED_OFFSETS_FILE_NAME);
+        committedOffsetsFile = new CommittedOffsetsFile(file);
+        if (file.createNewFile()) {
+            log.info("Created file: [{}] successfully", file);
+        } else {
+            // load committed offset and assign them in the consumer
+            final Map<Integer, Long> committedOffsets = committedOffsetsFile.read();
+            final Set<Map.Entry<Integer, Long>> entries = committedOffsets.entrySet();
+
+            if (!entries.isEmpty()) {
+                // assign topic partitions from the earlier committed offsets file.
+                assignedMetaPartitions = committedOffsets.keySet();
+                Set<TopicPartition> assignedTopicPartitions = assignedMetaPartitions.stream()
+                        .map(x -> new TopicPartition(Topic.REMOTE_LOG_METADATA_TOPIC_NAME, x))
+                        .collect(Collectors.toSet());
+                consumer.assign(assignedTopicPartitions);
+
+                // seek to the committed offset
+                for (Map.Entry<Integer, Long> entry : entries) {
+                    this.committedOffsets.put(entry.getKey(), entry.getValue());
+                    consumer.seek(new TopicPartition(Topic.REMOTE_LOG_METADATA_TOPIC_NAME, entry.getKey()),
+                            entry.getValue());
+                }
+            }
+        }
+    }
+
+    @Override
+    public void run() {
+        log.info("Started Consumer task thread.");
+        try {
+            while (!closed) {
+                synchronized (lock) {
+                    while (assignedMetaPartitions.isEmpty()) {
+                        // if no partitions are assigned, wait till they are assigned.
+                        log.info("Waiting for assigned meta partitions");
+                        try {
+                            lock.wait();
+                        } catch (InterruptedException e) {
+                            throw new KafkaException(e);
+                        }
+                    }
+
+                    if (reassign) {
+                        // whenever it is assigned, we should wait to process any get metadata requests until we
+                        //poll all the messages till the endoffsets captured now.
+                        Set<TopicPartition> assignedTopicPartitions = assignedMetaPartitions.stream()
+                                .map(x -> new TopicPartition(Topic.REMOTE_LOG_METADATA_TOPIC_NAME, x))
+                                .collect(Collectors.toSet());
+                        log.info("Reassigning partitions to consumer task [{}]", assignedTopicPartitions);
+                        consumer.assign(assignedTopicPartitions);
+                        log.info("Reassigned partitions to consumer task [{}]", assignedTopicPartitions);
+
+                        log.info("Fetching end offsets to consumer task [{}]", assignedTopicPartitions);
+                        Map<TopicPartition, Long> endOffsets;
+                        while (true) {
+                            try {
+                                endOffsets = consumer.endOffsets(assignedTopicPartitions, Duration.ofSeconds(30));
+                                break;
+                            } catch (Exception e) {
+                                // ignore exception
+                                log.info("#### Error encountered in fetching end offsets");
+                            }
+                        }
+                        log.info("Fetched end offsets to consumer task [{}]", endOffsets);
+
+                        for (Map.Entry<TopicPartition, Long> entry
+                                : endOffsets.entrySet()) {
+                            if (entry.getValue() > 0) {
+                                targetEndOffsets.put(entry.getKey().partition(), entry.getValue());
+                            }
+                        }
+
+                        reassign = false;
+                    }
+                }
+
+                log.info("Polling consumer to receive remote log metadata topic records");
+                ConsumerRecords<String, RemoteLogSegmentMetadata> consumerRecords
+                        = consumer.poll(Duration.ofSeconds(30L));
+                for (ConsumerRecord<String, RemoteLogSegmentMetadata> record : consumerRecords) {
+                    try {
+                        String key = record.key();
+                        TopicPartition tp = buildTopicPartition(key);
+                        remoteLogSegmentMetadataUpdater.updateRemoteLogSegmentMetadata(tp, record.value());
+                        committedOffsets.put(record.partition(), record.offset());
+                    } catch (WakeupException e) {
+                        throw e;
+                    } catch (Exception e) {
+                        log.error(String.format("Error encountered while consuming record: {%s}", record), e);
+                    }
+                }
+
+                // check whether messages are received till end offsets or not for the assigned metadata partitions.
+                if (!targetEndOffsets.isEmpty()) {
+                    for (Map.Entry<Integer, Long> entry : targetEndOffsets.entrySet()) {
+                        final Long offset = committedOffsets.getOrDefault(entry.getKey(), 0L);
+                        if (offset >= entry.getValue()) {
+                            targetEndOffsets.remove(entry.getKey());
+                        }
+                    }
+                }
+
+                // write data and sync offsets.
+                syncCommittedDataAndOffsets(false);
+            }
+        } catch (Exception e) {
+            if (closed) {
+                log.info("ConsumerTask is closed");
+            } else {
+                //todo-tier add a metric that the consumer task is failed. This will allow users can take an action
+                // based on the error.
+                log.error("Error occurred in consumer task", e);
+            }
+        } finally {
+            log.info("Exiting from consumer task thread");
+            if (!closed) {
+                // sync this only if it is not closed as it comes here in a non-graceful error.
+                syncCommittedDataAndOffsets(true);
+            }
+        }
+    }
+
+    public void syncCommittedDataAndOffsets(boolean forceSync) {
+        if (!forceSync && System.currentTimeMillis() - lastSyncedTs < 60_000) {
+            return;
+        }
+
+        try {
+            remoteLogSegmentMetadataUpdater.syncLogMetadataDataFile();
+            committedOffsetsFile.write(committedOffsets);
+            lastSyncedTs = System.currentTimeMillis();
+        } catch (IOException e) {
+            log.error("Error encountered while writing committed offsets to a local file", e);
+        }
+    }
+
+    public void reassignForPartitions(Set<TopicPartition> partitions) {
+        Objects.requireNonNull(partitions, "partitions can not be null");
+
+        log.info("Reassigning for user partitions {}", partitions);
+        synchronized (lock) {
+            // check for the corresponding partitions.
+            Set<Integer> newlyAssignedPartitions = new HashSet<>();
+            for (TopicPartition tp : partitions) {
+                newlyAssignedPartitions.add(remoteLogSegmentMetadataUpdater.metadataPartitionFor(tp));
+            }
+            reassignedTopicPartitions = new HashSet<>(partitions);
+            assignedMetaPartitions = Collections.unmodifiableSet(newlyAssignedPartitions);
+            log.info("Newly assigned metadata partitions {}", assignedMetaPartitions);
+            reassign = true;
+
+            lock.notifyAll();
+        }
+    }
+
+    public void removeAssignmentsForPartitions(Set<TopicPartition> partitions) {
+        synchronized (lock) {
+            Set<TopicPartition> updatedReassignedPartitions = new HashSet<>(reassignedTopicPartitions);
+            updatedReassignedPartitions.removeAll(partitions);
+            Set<Integer> updatedAssignedMetaPartitions = new HashSet<>();
+            for (TopicPartition tp : updatedReassignedPartitions) {
+                updatedAssignedMetaPartitions.add(remoteLogSegmentMetadataUpdater.metadataPartitionFor(tp));
+            }
+
+            if (!updatedAssignedMetaPartitions.equals(assignedMetaPartitions)) {
+                reassignedTopicPartitions = Collections.unmodifiableSet(updatedReassignedPartitions);
+                assignedMetaPartitions = Collections.unmodifiableSet(updatedAssignedMetaPartitions);
+                reassign = true;
+                lock.notifyAll();
+            }
+        }
+    }
+
+    public Long committedOffset(int partition) {
+        return committedOffsets.getOrDefault(partition, -1L);
+    }
+
+    public void close() {
+        closed = true;
+        consumer.wakeup();
+        syncCommittedDataAndOffsets(true);
+    }
+
+    private TopicPartition buildTopicPartition(String key) {
+        int index = key.lastIndexOf("-");
+        if (index < 0) {
+            throw new IllegalArgumentException(
+                    "Given key is not of topic partition format like <topic>-<partition>.");
+        }
+        String topic = key.substring(0, index);
+        int partition = Integer.parseInt(key.substring(index + 1));
+        return new TopicPartition(topic, partition);
+    }
+
+    public boolean assignedPartition(int partition) {
+        return assignedMetaPartitions.contains(partition);
+    }
+
+}

--- a/clients/src/main/java/org/apache/kafka/common/log/remote/metadata/storage/RLMMWithTopicStorage.java
+++ b/clients/src/main/java/org/apache/kafka/common/log/remote/metadata/storage/RLMMWithTopicStorage.java
@@ -14,13 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.kafka.common.log.remote.storage;
+package org.apache.kafka.common.log.remote.metadata.storage;
 
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
-import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.Callback;
 import org.apache.kafka.clients.producer.KafkaProducer;
@@ -29,8 +27,10 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.errors.WakeupException;
 import org.apache.kafka.common.internals.Topic;
+import org.apache.kafka.common.log.remote.storage.RemoteLogMetadataManager;
+import org.apache.kafka.common.log.remote.storage.RemoteLogSegmentId;
+import org.apache.kafka.common.log.remote.storage.RemoteLogSegmentMetadata;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.utils.KafkaThread;
@@ -43,19 +43,12 @@ import static org.apache.kafka.clients.consumer.ConsumerConfig.VALUE_DESERIALIZE
 import static org.apache.kafka.clients.producer.ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG;
 import static org.apache.kafka.clients.producer.ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG;
 
-import java.io.BufferedReader;
-import java.io.BufferedWriter;
-import java.io.Closeable;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
-import java.io.OutputStreamWriter;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -69,7 +62,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 /**
@@ -107,7 +99,7 @@ public class RLMMWithTopicStorage implements RemoteLogMetadataManager, RemoteLog
     private String logDir;
     private Map<String, ?> configs;
 
-    private CommittedLogMetadataFile committedLogMetadataFile;
+    private RLMMWithTopicStorage.CommittedLogMetadataFile committedLogMetadataFile;
     private ConsumerTask consumerTask;
     private boolean initialized;
 
@@ -139,7 +131,7 @@ public class RLMMWithTopicStorage implements RemoteLogMetadataManager, RemoteLog
 
         int partitionNo = metadataPartitionFor(remoteLogSegmentId.topicPartition());
         try {
-            final ProducerCallback callback = new ProducerCallback();
+            final RLMMWithTopicStorage.ProducerCallback callback = new RLMMWithTopicStorage.ProducerCallback();
             producer.send(new ProducerRecord<>(Topic.REMOTE_LOG_METADATA_TOPIC_NAME, partitionNo,
                             remoteLogSegmentId.topicPartition().toString(), remoteLogSegmentMetadata),
                     callback)
@@ -315,14 +307,14 @@ public class RLMMWithTopicStorage implements RemoteLogMetadataManager, RemoteLog
         }
 
         File metadataLogFile = new File(logDir, COMMITTED_LOG_METADATA_FILE_NAME);
-        committedLogMetadataFile = new CommittedLogMetadataFile(metadataLogFile);
+        committedLogMetadataFile = new RLMMWithTopicStorage.CommittedLogMetadataFile(metadataLogFile);
 
         log.info("RLMMWithTopicStorage is initialized: {}", this);
     }
 
     private void loadMetadataStore() {
         try {
-            final CommittedLogMetadataFile.Data data = committedLogMetadataFile.read();
+            final RLMMWithTopicStorage.CommittedLogMetadataFile.Data data = committedLogMetadataFile.read();
             idWithSegmentMetadata.putAll(data.idWithSegmentMetadata);
             for (Map.Entry<TopicPartition, Map<Long, RemoteLogSegmentId>> entry : data.partitionsWithSegmentIds
                     .entrySet()) {
@@ -398,10 +390,10 @@ public class RLMMWithTopicStorage implements RemoteLogMetadataManager, RemoteLog
         }
 
         @SuppressWarnings("unchecked")
-        public synchronized Data read() throws IOException, ClassNotFoundException {
+        public synchronized RLMMWithTopicStorage.CommittedLogMetadataFile.Data read() throws IOException, ClassNotFoundException {
             // checking for empty files.
             if (metadataStoreFile.length() == 0) {
-                return new Data(Collections.emptyMap(), Collections.emptyMap());
+                return new RLMMWithTopicStorage.CommittedLogMetadataFile.Data(Collections.emptyMap(), Collections.emptyMap());
             }
 
             try (FileInputStream fis = new FileInputStream(metadataStoreFile);
@@ -421,7 +413,7 @@ public class RLMMWithTopicStorage implements RemoteLogMetadataManager, RemoteLog
                 Map<RemoteLogSegmentId, RemoteLogSegmentMetadata> idWithSegmentMetadata =
                         (Map<RemoteLogSegmentId, RemoteLogSegmentMetadata>) readObject;
 
-                return new Data(idWithSegmentMetadata, partitionsWithSegmentIds);
+                return new RLMMWithTopicStorage.CommittedLogMetadataFile.Data(idWithSegmentMetadata, partitionsWithSegmentIds);
             }
         }
 
@@ -435,55 +427,6 @@ public class RLMMWithTopicStorage implements RemoteLogMetadataManager, RemoteLog
                 this.idWithSegmentMetadata = idWithSegmentMetadata;
                 this.partitionsWithSegmentIds = partitionsWithSegmentIds;
             }
-        }
-    }
-
-    // There are similar implementations in core/streams about offset checkpoint file.
-    // We can not reuse them as they exist in core and streams modules and we do not need to store topic name as it is
-    // same. We do not want this class to be moved into core, better to keep this out in clients or a new module.
-    private static class CommittedOffsetsFile {
-        private final File offsetsFile;
-
-        private static final Pattern MINIMUM_ONE_WHITESPACE = Pattern.compile("\\s+");
-
-        CommittedOffsetsFile(File offsetsFile) {
-            this.offsetsFile = offsetsFile;
-        }
-
-        public synchronized void write(Map<Integer, Long> committedOffsets) throws IOException {
-            File newOffsetsFile = new File(offsetsFile.getAbsolutePath() + ".new");
-
-            FileOutputStream fos = new FileOutputStream(newOffsetsFile);
-            try (final BufferedWriter writer = new BufferedWriter(
-                    new OutputStreamWriter(fos, StandardCharsets.UTF_8))) {
-                for (Map.Entry<Integer, Long> entry : committedOffsets.entrySet()) {
-                    writer.write(entry.getKey() + " " + entry.getValue());
-                    writer.newLine();
-                }
-
-                writer.flush();
-                fos.getFD().sync();
-            }
-
-            Utils.atomicMoveWithFallback(newOffsetsFile.toPath(), offsetsFile.toPath());
-        }
-
-        public synchronized Map<Integer, Long> read() throws IOException {
-            Map<Integer, Long> partitionOffsets = new HashMap<>();
-            try (BufferedReader bufferedReader = Files.newBufferedReader(offsetsFile.toPath(),
-                    StandardCharsets.UTF_8)) {
-                String line = null;
-                while ((line = bufferedReader.readLine()) != null) {
-                    String[] strings = MINIMUM_ONE_WHITESPACE.split(line);
-                    if (strings.length != 2) {
-                        throw new IOException("Invalid format in line: []" + line);
-                    }
-                    int partition = Integer.parseInt(strings[0]);
-                    long offset = Long.parseLong(strings[1]);
-                    partitionOffsets.put(partition, offset);
-                }
-            }
-            return partitionOffsets;
         }
     }
 
@@ -508,7 +451,7 @@ public class RLMMWithTopicStorage implements RemoteLogMetadataManager, RemoteLog
         props.put(ProducerConfig.CLIENT_ID_CONFIG, createClientId("producer"));
 
         props.put(KEY_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringSerializer");
-        props.put(VALUE_SERIALIZER_CLASS_CONFIG, RLMMSerializer.class.getName());
+        props.put(VALUE_SERIALIZER_CLASS_CONFIG, new RLSMSerDe().serializer().getClass().getName());
         props.put(ProducerConfig.ACKS_CONFIG, "all");
         props.put(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, 1);
         props.put(ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, Integer.MAX_VALUE);
@@ -535,243 +478,9 @@ public class RLMMWithTopicStorage implements RemoteLogMetadataManager, RemoteLog
         props.put(ConsumerConfig.METADATA_MAX_AGE_CONFIG, 30 * 1000);
         props.put(ConsumerConfig.EXCLUDE_INTERNAL_TOPICS_CONFIG, false);
         props.put(KEY_DESERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringDeserializer");
-        props.put(VALUE_DESERIALIZER_CLASS_CONFIG, RLMMDeserializer.class.getName());
+        props.put(VALUE_DESERIALIZER_CLASS_CONFIG, new RLSMSerDe().deserializer().getClass().getName());
 
         this.consumer = new KafkaConsumer<>(props);
-    }
-
-    private static class ConsumerTask implements Runnable, Closeable {
-        private static final Logger log = LoggerFactory.getLogger(ConsumerTask.class);
-        private final KafkaConsumer<String, RemoteLogSegmentMetadata> consumer;
-        private final RemoteLogSegmentMetadataUpdater remoteLogSegmentMetadataUpdater;
-        private final CommittedOffsetsFile committedOffsetsFile;
-
-        private final Object lock = new Object();
-        private volatile Set<Integer> assignedMetaPartitions = Collections.emptySet();
-        private Set<TopicPartition> reassignedTopicPartitions;
-
-        private volatile boolean closed = false;
-        private volatile boolean reassign = false;
-
-        private Map<Integer, Long> targetEndOffsets = new ConcurrentHashMap<>();
-
-        // map of topic-partition vs committed offsets
-        private Map<Integer, Long> committedOffsets = new ConcurrentHashMap<>();
-
-        private static final String COMMITTED_OFFSETS_FILE_NAME = "_rlmm_committed_offsets";
-        private long lastSyncedTs = System.currentTimeMillis();
-
-        public ConsumerTask(KafkaConsumer<String, RemoteLogSegmentMetadata> consumer,
-                            String logDirStr,
-                            RemoteLogSegmentMetadataUpdater remoteLogSegmentMetadataUpdater) throws IOException {
-            this.consumer = consumer;
-            final File logDir = new File(logDirStr);
-            this.remoteLogSegmentMetadataUpdater = remoteLogSegmentMetadataUpdater;
-
-            if (!logDir.exists()) {
-                throw new IllegalArgumentException("log.dir [" + logDirStr + "] does not exist.");
-            }
-
-            // look whether the committed file exists or not.
-            File file = new File(logDir, COMMITTED_OFFSETS_FILE_NAME);
-            committedOffsetsFile = new CommittedOffsetsFile(file);
-            if (file.createNewFile()) {
-                log.info("Created file: [{}] successfully", file);
-            } else {
-                // load committed offset and assign them in the consumer
-                final Map<Integer, Long> committedOffsets = committedOffsetsFile.read();
-                final Set<Map.Entry<Integer, Long>> entries = committedOffsets.entrySet();
-
-                if (!entries.isEmpty()) {
-                    // assign topic partitions from the earlier committed offsets file.
-                    assignedMetaPartitions = committedOffsets.keySet();
-                    Set<TopicPartition> assignedTopicPartitions = assignedMetaPartitions.stream()
-                            .map(x -> new TopicPartition(Topic.REMOTE_LOG_METADATA_TOPIC_NAME, x))
-                            .collect(Collectors.toSet());
-                    consumer.assign(assignedTopicPartitions);
-
-                    // seek to the committed offset
-                    for (Map.Entry<Integer, Long> entry : entries) {
-                        this.committedOffsets.put(entry.getKey(), entry.getValue());
-                        consumer.seek(new TopicPartition(Topic.REMOTE_LOG_METADATA_TOPIC_NAME, entry.getKey()),
-                                entry.getValue());
-                    }
-                }
-            }
-        }
-
-        @Override
-        public void run() {
-            log.info("Started Consumer task thread.");
-            try {
-                while (!closed) {
-                    synchronized (lock) {
-                        while (assignedMetaPartitions.isEmpty()) {
-                            // if no partitions are assigned, wait till they are assigned.
-                            log.info("Waiting for assigned meta partitions");
-                            try {
-                                lock.wait();
-                            } catch (InterruptedException e) {
-                                throw new KafkaException(e);
-                            }
-                        }
-
-                        if (reassign) {
-                            // whenever it is assigned, we should wait to process any get metadata requests until we
-                            //poll all the messages till the endoffsets captured now.
-                            Set<TopicPartition> assignedTopicPartitions = assignedMetaPartitions.stream()
-                                    .map(x -> new TopicPartition(Topic.REMOTE_LOG_METADATA_TOPIC_NAME, x))
-                                    .collect(Collectors.toSet());
-                            log.info("Reassigning partitions to consumer task [{}]", assignedTopicPartitions);
-                            consumer.assign(assignedTopicPartitions);
-                            log.info("Reassigned partitions to consumer task [{}]", assignedTopicPartitions);
-
-                            log.info("Fetching end offsets to consumer task [{}]", assignedTopicPartitions);
-                            Map<TopicPartition, Long> endOffsets;
-                            while (true) {
-                                try {
-                                    endOffsets = consumer.endOffsets(assignedTopicPartitions, Duration.ofSeconds(30));
-                                    break;
-                                } catch (Exception e) {
-                                    // ignore exception
-                                    log.info("#### Error encountered in fetching end offsets");
-                                }
-                            }
-                            log.info("Fetched end offsets to consumer task [{}]", endOffsets);
-
-                            for (Map.Entry<TopicPartition, Long> entry
-                                    : endOffsets.entrySet()) {
-                                if (entry.getValue() > 0) {
-                                    targetEndOffsets.put(entry.getKey().partition(), entry.getValue());
-                                }
-                            }
-
-                            reassign = false;
-                        }
-                    }
-
-                    log.info("Polling consumer to receive remote log metadata topic records");
-                    ConsumerRecords<String, RemoteLogSegmentMetadata> consumerRecords
-                            = consumer.poll(Duration.ofSeconds(30L));
-                    for (ConsumerRecord<String, RemoteLogSegmentMetadata> record : consumerRecords) {
-                        try {
-                            String key = record.key();
-                            TopicPartition tp = buildTopicPartition(key);
-                            remoteLogSegmentMetadataUpdater.updateRemoteLogSegmentMetadata(tp, record.value());
-                            committedOffsets.put(record.partition(), record.offset());
-                        } catch (WakeupException e) {
-                            throw e;
-                        } catch (Exception e) {
-                            log.error(String.format("Error encountered while consuming record: {%s}", record), e);
-                        }
-                    }
-
-                    // check whether messages are received till end offsets or not for the assigned metadata partitions.
-                    if (!targetEndOffsets.isEmpty()) {
-                        for (Map.Entry<Integer, Long> entry : targetEndOffsets.entrySet()) {
-                            final Long offset = committedOffsets.getOrDefault(entry.getKey(), 0L);
-                            if (offset >= entry.getValue()) {
-                                targetEndOffsets.remove(entry.getKey());
-                            }
-                        }
-                    }
-
-                    // write data and sync offsets.
-                    syncCommittedDataAndOffsets(false);
-                }
-            } catch (Exception e) {
-                if (closed) {
-                    log.info("ConsumerTask is closed");
-                } else {
-                    //todo-tier add a metric that the consumer task is failed. This will allow users can take an action
-                    // based on the error.
-                    log.error("Error occurred in consumer task", e);
-                }
-            } finally {
-                log.info("Exiting from consumer task thread");
-                if (!closed) {
-                    // sync this only if it is not closed as it comes here in a non-graceful error.
-                    syncCommittedDataAndOffsets(true);
-                }
-            }
-        }
-
-        public void syncCommittedDataAndOffsets(boolean forceSync) {
-            if (!forceSync && System.currentTimeMillis() - lastSyncedTs < 60_000) {
-                return;
-            }
-
-            try {
-                remoteLogSegmentMetadataUpdater.syncLogMetadataDataFile();
-                committedOffsetsFile.write(committedOffsets);
-                lastSyncedTs = System.currentTimeMillis();
-            } catch (IOException e) {
-                log.error("Error encountered while writing committed offsets to a local file", e);
-            }
-        }
-
-        public void reassignForPartitions(Set<TopicPartition> partitions) {
-            Objects.requireNonNull(partitions, "partitions can not be null");
-
-            log.info("Reassigning for user partitions {}", partitions);
-            synchronized (lock) {
-                // check for the corresponding partitions.
-                Set<Integer> newlyAssignedPartitions = new HashSet<>();
-                for (TopicPartition tp : partitions) {
-                    newlyAssignedPartitions.add(remoteLogSegmentMetadataUpdater.metadataPartitionFor(tp));
-                }
-                reassignedTopicPartitions = new HashSet<>(partitions);
-                assignedMetaPartitions = Collections.unmodifiableSet(newlyAssignedPartitions);
-                log.info("Newly assigned metadata partitions {}", assignedMetaPartitions);
-                reassign = true;
-
-                lock.notifyAll();
-            }
-        }
-
-        public void removeAssignmentsForPartitions(Set<TopicPartition> partitions) {
-            synchronized (lock) {
-                Set<TopicPartition> updatedReassignedPartitions = new HashSet<>(reassignedTopicPartitions);
-                updatedReassignedPartitions.removeAll(partitions);
-                Set<Integer> updatedAssignedMetaPartitions = new HashSet<>();
-                for (TopicPartition tp : updatedReassignedPartitions) {
-                    updatedAssignedMetaPartitions.add(remoteLogSegmentMetadataUpdater.metadataPartitionFor(tp));
-                }
-
-                if (!updatedAssignedMetaPartitions.equals(assignedMetaPartitions)) {
-                    reassignedTopicPartitions = Collections.unmodifiableSet(updatedReassignedPartitions);
-                    assignedMetaPartitions = Collections.unmodifiableSet(updatedAssignedMetaPartitions);
-                    reassign = true;
-                    lock.notifyAll();
-                }
-            }
-        }
-
-        public Long committedOffset(int partition) {
-            return committedOffsets.getOrDefault(partition, -1L);
-        }
-
-        public void close() {
-            closed = true;
-            consumer.wakeup();
-            syncCommittedDataAndOffsets(true);
-        }
-
-        private TopicPartition buildTopicPartition(String key) {
-            int index = key.lastIndexOf("-");
-            if (index < 0) {
-                throw new IllegalArgumentException(
-                        "Given key is not of topic partition format like <topic>-<partition>.");
-            }
-            String topic = key.substring(0, index);
-            int partition = Integer.parseInt(key.substring(index + 1));
-            return new TopicPartition(topic, partition);
-        }
-
-        public boolean assignedPartition(int partition) {
-            return assignedMetaPartitions.contains(partition);
-        }
-
     }
 
 
@@ -780,7 +489,7 @@ public class RLMMWithTopicStorage implements RemoteLogMetadataManager, RemoteLog
         @Override
         public byte[] serialize(String topic, RemoteLogSegmentMetadata data) {
             try {
-                return RemoteLogSegmentMetadata.asBytes(data);
+                return RemoteLogSegmentMetadata.asBytesWithJavaSerde(data);
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }
@@ -793,7 +502,7 @@ public class RLMMWithTopicStorage implements RemoteLogMetadataManager, RemoteLog
         @Override
         public RemoteLogSegmentMetadata deserialize(String topic, byte[] data) {
             try {
-                return RemoteLogSegmentMetadata.fromBytes(data);
+                return RemoteLogSegmentMetadata.fromBytesWithJavaSerde(data);
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }
@@ -802,10 +511,4 @@ public class RLMMWithTopicStorage implements RemoteLogMetadataManager, RemoteLog
     }
 }
 
-interface RemoteLogSegmentMetadataUpdater {
-    void updateRemoteLogSegmentMetadata(TopicPartition tp, RemoteLogSegmentMetadata remoteLogSegmentMetadata);
 
-    void syncLogMetadataDataFile() throws IOException;
-
-    int metadataPartitionFor(TopicPartition tp);
-}

--- a/clients/src/main/java/org/apache/kafka/common/log/remote/metadata/storage/RLSMSerDe.java
+++ b/clients/src/main/java/org/apache/kafka/common/log/remote/metadata/storage/RLSMSerDe.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.log.remote.metadata.storage;
+
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.log.remote.storage.RemoteLogSegmentId;
+import org.apache.kafka.common.log.remote.storage.RemoteLogSegmentMetadata;
+import org.apache.kafka.common.protocol.types.Field;
+import org.apache.kafka.common.protocol.types.Schema;
+import org.apache.kafka.common.protocol.types.Struct;
+import org.apache.kafka.common.protocol.types.Type;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.serialization.Serializer;
+
+import java.nio.ByteBuffer;
+
+public class RLSMSerDe extends Serdes.WrapperSerde<RemoteLogSegmentMetadata> {
+
+    public static final Field.Str TOPIC_FIELD = new Field.Str("topic", "Topic name");
+    public static final Field.Int32 PARTITION_FIELD = new Field.Int32("partition", "Partition number");
+    public static final Schema TOPIC_PARTITION_SCHEMA = new Schema(TOPIC_FIELD, PARTITION_FIELD);
+
+    private static final String TOPIC_PARTITION = "topic-partition";
+    public static final String ID = "id";
+    public static final Field.UUID ID_FIELD = new Field.UUID(ID, " UUID of this entry");
+    private static final Schema REMOTE_LOG_SEGMENT_ID_SCHEMA_V0 = new Schema(
+            new Field(TOPIC_PARTITION, TOPIC_PARTITION_SCHEMA, " Topic partition"),
+            ID_FIELD);
+
+    public static final String REMOTE_LOG_SEGMENT_ID_NAME = "remote-log-segment-id";
+    private static final Field REMOTE_LOG_SEGMENT_ID_FIELD = new Field(REMOTE_LOG_SEGMENT_ID_NAME,
+            REMOTE_LOG_SEGMENT_ID_SCHEMA_V0, "Remote log segment id");
+
+    private static final Field.Int64 START_OFFSET_FIELD = new Field.Int64("start-offset",
+            "Start offset of the remote log segment");
+    private static final Field.Int64 END_OFFSET_FIELD = new Field.Int64("end-offset",
+            "End offset of the remote log segment");
+    private static final Field.Int32 LEADER_EPOCH_FIELD = new Field.Int32("leader-epoch",
+            "Leader epoch value of the remote log segment");
+    private static final Field.Int64 MAX_TIMESTAMP_FIELD = new Field.Int64("max-timestamp",
+            "Max time stamp in the remote log segment");
+    private static final Field.Int64 CREATED_TIMESTAMP_FIELD = new Field.Int64("created-timestamp",
+            "Created timestamp value of the remote log segment");
+    private static final Field.Bool MARKED_FOR_DELETION_FIELD = new Field.Bool("marked-for-deletion",
+            "Whether this segment is marked for deletion or not.");
+    private static final String REMOTE_LOG_SEGMENT_CONTEXT_NAME = "remote-log-segment-context";
+    private static final Field REMOTE_LOG_CONTEXT_FIELD = new Field(REMOTE_LOG_SEGMENT_CONTEXT_NAME, Type.NULLABLE_BYTES,
+            "Remote log segment context of the segment");
+
+    private static final Schema SCHEMA_V0 = new Schema(
+            REMOTE_LOG_SEGMENT_ID_FIELD,
+            START_OFFSET_FIELD,
+            END_OFFSET_FIELD,
+            LEADER_EPOCH_FIELD,
+            MAX_TIMESTAMP_FIELD,
+            CREATED_TIMESTAMP_FIELD,
+            MARKED_FOR_DELETION_FIELD,
+            REMOTE_LOG_CONTEXT_FIELD);
+
+    private static final Schema[] SCHEMAS = {SCHEMA_V0};
+
+    public RLSMSerDe() {
+        super(new RLSMSerializer(), new RLSMDeserializer());
+    }
+
+    public static class RLSMSerializer implements Serializer<RemoteLogSegmentMetadata> {
+
+        @Override
+        public byte[] serialize(String topic, RemoteLogSegmentMetadata data) {
+            Struct tpStruct = new Struct(TOPIC_PARTITION_SCHEMA);
+            tpStruct.set(TOPIC_FIELD, data.remoteLogSegmentId().topicPartition().topic());
+            tpStruct.set(PARTITION_FIELD, data.remoteLogSegmentId().topicPartition().partition());
+
+            Struct rlsIdStruct = new Struct(REMOTE_LOG_SEGMENT_ID_SCHEMA_V0);
+            rlsIdStruct.set(TOPIC_PARTITION, tpStruct);
+            rlsIdStruct.set("id", data.remoteLogSegmentId().id());
+
+            Struct rlsmStruct = new Struct(SCHEMA_V0);
+            rlsmStruct.set(REMOTE_LOG_SEGMENT_ID_NAME, rlsIdStruct);
+            rlsmStruct.set(START_OFFSET_FIELD, data.startOffset());
+            rlsmStruct.set(END_OFFSET_FIELD, data.endOffset());
+            rlsmStruct.set(LEADER_EPOCH_FIELD, data.leaderEpoch());
+            rlsmStruct.set(MAX_TIMESTAMP_FIELD, data.maxTimestamp());
+            rlsmStruct.set(CREATED_TIMESTAMP_FIELD, data.createdTimestamp());
+            rlsmStruct.set(MARKED_FOR_DELETION_FIELD, data.markedForDeletion());
+            final byte[] value = data.remoteLogSegmentContext();
+            rlsmStruct.set(REMOTE_LOG_SEGMENT_CONTEXT_NAME, value != null ? ByteBuffer.wrap(value) : null);
+
+            final int size = SCHEMA_V0.sizeOf(rlsmStruct);
+            final ByteBuffer byteBuffer = ByteBuffer.allocate(size + 2);
+            byteBuffer.putShort((short) 0);
+            SCHEMA_V0.write(byteBuffer, rlsmStruct);
+            byteBuffer.flip();
+            return byteBuffer.array();
+        }
+    }
+
+    public static final class RLSMDeserializer implements Deserializer<RemoteLogSegmentMetadata> {
+
+        @Override
+        public RemoteLogSegmentMetadata deserialize(String topic, byte[] data) {
+            final ByteBuffer byteBuffer = ByteBuffer.wrap(data);
+            short version = byteBuffer.getShort();
+
+            final Struct struct = SCHEMAS[version].read(byteBuffer);
+            final Struct rlsIdStruct = (Struct) struct.get(REMOTE_LOG_SEGMENT_ID_NAME);
+            final Struct tpStruct = (Struct) rlsIdStruct.get(TOPIC_PARTITION);
+
+            RemoteLogSegmentId rlsId = new RemoteLogSegmentId(
+                    new TopicPartition(tpStruct.get(TOPIC_FIELD), tpStruct.get(PARTITION_FIELD)),
+                    rlsIdStruct.get(ID_FIELD));
+
+            final ByteBuffer contextByteBuffer = struct.getBytes(REMOTE_LOG_SEGMENT_CONTEXT_NAME);
+            byte[] contextBytes = null;
+            if(contextByteBuffer != null) {
+                contextBytes = new byte[contextByteBuffer.remaining()];
+                contextByteBuffer.get(contextBytes, 0, contextBytes.length);
+            }
+
+            return new RemoteLogSegmentMetadata(rlsId,
+                    struct.get(START_OFFSET_FIELD),
+                    struct.get(END_OFFSET_FIELD),
+                    struct.get(MAX_TIMESTAMP_FIELD),
+                    struct.get(LEADER_EPOCH_FIELD),
+                    struct.get(CREATED_TIMESTAMP_FIELD),
+                    struct.get(MARKED_FOR_DELETION_FIELD),
+                    contextBytes
+            );
+        }
+    }
+}

--- a/clients/src/main/java/org/apache/kafka/common/log/remote/metadata/storage/RemoteLogSegmentMetadataUpdater.java
+++ b/clients/src/main/java/org/apache/kafka/common/log/remote/metadata/storage/RemoteLogSegmentMetadataUpdater.java
@@ -21,11 +21,32 @@ import org.apache.kafka.common.log.remote.storage.RemoteLogSegmentMetadata;
 
 import java.io.IOException;
 
-interface RemoteLogSegmentMetadataUpdater {
+/**
+ * This is invoked by {@link ConsumerTask} whenever there are updates for a topic partition on
+ * RemoteLogSegmentMetadata.
+ */
+public interface RemoteLogSegmentMetadataUpdater {
 
+    /**
+     * Update RemoteLogSegmentMetadata for a topic partition.
+     *
+     * @param tp
+     * @param remoteLogSegmentMetadata
+     */
     void updateRemoteLogSegmentMetadata(TopicPartition tp, RemoteLogSegmentMetadata remoteLogSegmentMetadata);
 
+    /**
+     * Sync the remote log metadata state maintained for this broker.
+     *
+     * @throws IOException
+     */
     void syncLogMetadataDataFile() throws IOException;
 
+    /**
+     * It returns partition number of remote log metadata topic for the given topic partition.
+     *
+     * @param tp
+     * @return
+     */
     int metadataPartitionFor(TopicPartition tp);
 }

--- a/clients/src/main/java/org/apache/kafka/common/log/remote/metadata/storage/RemoteLogSegmentMetadataUpdater.java
+++ b/clients/src/main/java/org/apache/kafka/common/log/remote/metadata/storage/RemoteLogSegmentMetadataUpdater.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.log.remote.metadata.storage;
+
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.log.remote.storage.RemoteLogSegmentMetadata;
+
+import java.io.IOException;
+
+interface RemoteLogSegmentMetadataUpdater {
+
+    void updateRemoteLogSegmentMetadata(TopicPartition tp, RemoteLogSegmentMetadata remoteLogSegmentMetadata);
+
+    void syncLogMetadataDataFile() throws IOException;
+
+    int metadataPartitionFor(TopicPartition tp);
+}

--- a/clients/src/main/java/org/apache/kafka/common/log/remote/storage/RemoteLogSegmentMetadata.java
+++ b/clients/src/main/java/org/apache/kafka/common/log/remote/storage/RemoteLogSegmentMetadata.java
@@ -158,20 +158,6 @@ public class RemoteLogSegmentMetadata implements Serializable {
                 original.remoteLogSegmentContext);
     }
 
-    public static byte[] asBytesWithJavaSerde(RemoteLogSegmentMetadata remoteLogSegmentMetadata) throws IOException {
-        try (ByteArrayOutputStream baos = new ByteArrayOutputStream(512);
-             ObjectOutputStream objectOutputStream = new ObjectOutputStream(baos)) {
-            objectOutputStream.writeObject(remoteLogSegmentMetadata);
-            return baos.toByteArray();
-        }
-    }
-
-    public static RemoteLogSegmentMetadata fromBytesWithJavaSerde(byte[] bytes) throws IOException, ClassNotFoundException {
-        try (ObjectInputStream objectInputStream = new ObjectInputStream(new ByteArrayInputStream(bytes))) {
-            return (RemoteLogSegmentMetadata) objectInputStream.readObject();
-        }
-    }
-
     @Override
     public String toString() {
         return "RemoteLogSegmentMetadata{" +

--- a/clients/src/test/java/org/apache/kafka/log/remote/metadata/storage/RLSMSerDesTest.java
+++ b/clients/src/test/java/org/apache/kafka/log/remote/metadata/storage/RLSMSerDesTest.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.log.remote.metadata.storage;
+
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.log.remote.metadata.storage.RLSMSerDe;
+import org.apache.kafka.common.log.remote.storage.RemoteLogSegmentId;
+import org.apache.kafka.common.log.remote.storage.RemoteLogSegmentMetadata;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.Serializer;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.UUID;
+
+public class RLSMSerDesTest {
+
+    @Test
+    public void testSerDes() throws Exception {
+        final String topic = "foo";
+        
+        // RLSM with context as non-null.
+        RemoteLogSegmentMetadata rlsmWithNoContext = new RemoteLogSegmentMetadata(
+                new RemoteLogSegmentId(new TopicPartition("bar", 0), UUID.randomUUID()),
+                1000L,
+                2000L,
+                System.currentTimeMillis() - 10000,
+                1,
+                System.currentTimeMillis(),
+                false,
+                null);
+        doTestSerDes(topic, rlsmWithNoContext);
+
+        // RLSM with context as non-null.
+        RemoteLogSegmentMetadata rlsmWithContext = new RemoteLogSegmentMetadata(
+                new RemoteLogSegmentId(new TopicPartition("bar", 0), UUID.randomUUID()),
+                2000L,
+                4000L,
+                System.currentTimeMillis() - 10000,
+                1,
+                System.currentTimeMillis(),
+                false,
+                "xyz".getBytes(StandardCharsets.UTF_8));
+        doTestSerDes(topic, rlsmWithContext);
+
+        //RLSM marked with deletion
+        RemoteLogSegmentMetadata rlsmMarkedDelete = new RemoteLogSegmentMetadata(
+                new RemoteLogSegmentId(new TopicPartition("bar", 0), UUID.randomUUID()),
+                2000L,
+                4000L,
+                System.currentTimeMillis() - 10000,
+                1,
+                System.currentTimeMillis(),
+                true,
+                "xyz".getBytes(StandardCharsets.UTF_8));
+        doTestSerDes(topic, rlsmMarkedDelete);
+
+    }
+
+    private void doTestSerDes(final String topic, final RemoteLogSegmentMetadata rlsm) {
+        try (RLSMSerDe rlsmSerDe = new RLSMSerDe()) {
+            rlsmSerDe.configure(Collections.emptyMap(), false);
+
+            final Serializer<RemoteLogSegmentMetadata> serializer = rlsmSerDe.serializer();
+            final byte[] serializedBytes = serializer.serialize(topic, rlsm);
+
+            final Deserializer<RemoteLogSegmentMetadata> deserializer = rlsmSerDe.deserializer();
+            final RemoteLogSegmentMetadata deserializedRlsm = deserializer.deserialize(topic, serializedBytes);
+
+            Assert.assertEquals(rlsm, deserializedRlsm);
+        }
+    }
+}

--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -39,7 +39,6 @@ import kafka.server.{BrokerTopicStats, FetchDataInfo, FetchHighWatermark, FetchI
 import kafka.utils._
 import org.apache.kafka.common.errors._
 import org.apache.kafka.common.internals.Topic
-import org.apache.kafka.common.log.remote.storage.RLMMWithTopicStorage
 import org.apache.kafka.common.record.FileRecords.TimestampAndOffset
 import org.apache.kafka.common.record._
 import org.apache.kafka.common.requests.FetchResponse.AbortedTransaction

--- a/core/src/main/scala/kafka/server/KafkaApis.scala
+++ b/core/src/main/scala/kafka/server/KafkaApis.scala
@@ -46,7 +46,7 @@ import org.apache.kafka.common.config.ConfigResource
 import org.apache.kafka.common.errors._
 import org.apache.kafka.common.internals.FatalExitError
 import org.apache.kafka.common.internals.Topic.{GROUP_METADATA_TOPIC_NAME, REMOTE_LOG_METADATA_TOPIC_NAME, TRANSACTION_STATE_TOPIC_NAME, isInternal}
-import org.apache.kafka.common.log.remote.storage.RLMMWithTopicStorage
+import org.apache.kafka.common.log.remote.metadata.storage.RLMMWithTopicStorage
 import org.apache.kafka.common.message.AlterPartitionReassignmentsResponseData.{ReassignablePartitionResponse, ReassignableTopicResponse}
 import org.apache.kafka.common.message.CreateTopicsRequestData.CreatableTopic
 import org.apache.kafka.common.message.CreateTopicsResponseData.{CreatableTopicResult, CreatableTopicResultCollection}

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -33,7 +33,7 @@ import org.apache.kafka.common.Reconfigurable
 import org.apache.kafka.common.config.ConfigDef.{ConfigKey, ValidList}
 import org.apache.kafka.common.config.internals.BrokerSecurityConfigs
 import org.apache.kafka.common.config.{AbstractConfig, ConfigDef, ConfigException, SaslConfigs, SecurityConfig, SslClientAuth, SslConfigs, TopicConfig}
-import org.apache.kafka.common.log.remote.storage.RLMMWithTopicStorage
+import org.apache.kafka.common.log.remote.metadata.storage.RLMMWithTopicStorage
 import org.apache.kafka.common.metrics.Sensor
 import org.apache.kafka.common.network.ListenerName
 import org.apache.kafka.common.record.{LegacyRecord, Records, TimestampType}

--- a/core/src/test/scala/unit/kafka/log/remote/RLMMWithTopicStorageTest.scala
+++ b/core/src/test/scala/unit/kafka/log/remote/RLMMWithTopicStorageTest.scala
@@ -31,7 +31,8 @@ import org.junit.{Assert, Before, Test}
 import scala.collection.JavaConverters._
 
 /**
- *
+ * This test is added here as it needs the brokers to be run to test the `RemoteLogMetadataManager` implementation
+ * based on topic storage.
  */
 class RLMMWithTopicStorageTest extends IntegrationTestHarness {
 
@@ -44,6 +45,32 @@ class RLMMWithTopicStorageTest extends IntegrationTestHarness {
   val tp3 = new TopicPartition("bar", 1)
 
   val allTopicPartitions: util.Set[TopicPartition] = Set(tp0, tp1, tp2, tp3).asJava
+
+  val context: Array[Byte] = "random".getBytes()
+
+  val rlSegIdTp0_0_100 = new RemoteLogSegmentId(tp0, UUID.randomUUID)
+  val rlSegMetTp0_0_100 = new RemoteLogSegmentMetadata(rlSegIdTp0_0_100, 0L, 100L, -1L, 1, context)
+
+  val rlSegIdTp0_101_200 = new RemoteLogSegmentId(tp0, UUID.randomUUID)
+  val rlSegMetTp0_101_200 = new RemoteLogSegmentMetadata(rlSegIdTp0_101_200, 101L, 200L, -1L, 1, context)
+
+  val rlSegIdTp1_101_300 = new RemoteLogSegmentId(tp1, UUID.randomUUID)
+  val rlSegMetTp1_101_300 = new RemoteLogSegmentMetadata(rlSegIdTp1_101_300, 101L, 300L, -1L, 1, context)
+
+  val rlSegIdTp2_150_400 = new RemoteLogSegmentId(tp2, UUID.randomUUID)
+  val rlSegMetTp2_150_400 = new RemoteLogSegmentMetadata(rlSegIdTp2_150_400, 150L, 400L, -1L, 1, context)
+
+  val rlSegIdTp2_401_700 = new RemoteLogSegmentId(tp2, UUID.randomUUID)
+  val rlSegMetTp2_401_700 = new RemoteLogSegmentMetadata(rlSegIdTp2_401_700, 401L, 700L, -1L, 1, context)
+
+  val rlSegIdTp2_501_1000 = new RemoteLogSegmentId(tp2, UUID.randomUUID)
+  val rlSegMetTp2_501_1000 = new RemoteLogSegmentMetadata(rlSegIdTp2_501_1000, 501L, 1000L, -1L, 1, context)
+
+  val rlSegIdTp3_101_700 = new RemoteLogSegmentId(tp3, UUID.randomUUID)
+  val rlSegMetTp3_101 = new RemoteLogSegmentMetadata(rlSegIdTp3_101_700, 101L, 700L, -1L, 1, context)
+
+  val rlSegIdTp3_701_1900 = new RemoteLogSegmentId(tp3, UUID.randomUUID)
+  val rlSegMetTp3_701_1900 = new RemoteLogSegmentMetadata(rlSegIdTp3_701_1900, 701L, 1900L, -1L, 1, context)
 
   def tmpLogDirPathAsStr: String = tmpLogDirPath.toString
 
@@ -60,17 +87,6 @@ class RLMMWithTopicStorageTest extends IntegrationTestHarness {
   @throws[Exception]
   def testPutAndGetRemoteLogMetadata(): Unit = {
 
-    val rlSegIdTp0_0 = new RemoteLogSegmentId(tp0, UUID.randomUUID)
-    val rlSegMetTp0_0 = new RemoteLogSegmentMetadata(rlSegIdTp0_0, 0L, 100L, -1L, 1, tp0.toString.getBytes)
-
-    val rlSegIdTp0_101 = new RemoteLogSegmentId(tp0, UUID.randomUUID)
-    val rlSegMetTp0_101 = new RemoteLogSegmentMetadata(rlSegIdTp0_101, 101L, 200L, -1L, 1, tp0.toString.getBytes)
-
-    val rlSegIdTp1_101 = new RemoteLogSegmentId(tp1, UUID.randomUUID)
-    val rlSegMetTp1_101 = new RemoteLogSegmentMetadata(rlSegIdTp1_101, 101L, 200L, -1L, 1, tp1.toString.getBytes)
-
-    val rlSegIdTp2_401 = new RemoteLogSegmentId(tp2, UUID.randomUUID)
-    val rlSegMetTp2_401 = new RemoteLogSegmentMetadata(rlSegIdTp2_401, 401L, 700L, -1L, 1, tp1.toString.getBytes)
     var mayBeRlmmWithTopicStorage: Option[RLMMWithTopicStorage] = None
 
     try {
@@ -78,17 +94,17 @@ class RLMMWithTopicStorageTest extends IntegrationTestHarness {
       val rlmmWithTopicStorage = mayBeRlmmWithTopicStorage.get
       rlmmWithTopicStorage.onPartitionLeadershipChanges(allTopicPartitions, Set.empty[TopicPartition].asJava)
 
-      rlmmWithTopicStorage.putRemoteLogSegmentData(rlSegIdTp0_0, rlSegMetTp0_0)
-      rlmmWithTopicStorage.putRemoteLogSegmentData(rlSegIdTp0_101, rlSegMetTp0_101)
-      rlmmWithTopicStorage.putRemoteLogSegmentData(rlSegIdTp1_101, rlSegMetTp1_101)
-      rlmmWithTopicStorage.putRemoteLogSegmentData(rlSegIdTp2_401, rlSegMetTp2_401)
+      rlmmWithTopicStorage.putRemoteLogSegmentData(rlSegIdTp0_0_100, rlSegMetTp0_0_100)
+      rlmmWithTopicStorage.putRemoteLogSegmentData(rlSegIdTp0_101_200, rlSegMetTp0_101_200)
+      rlmmWithTopicStorage.putRemoteLogSegmentData(rlSegIdTp1_101_300, rlSegMetTp1_101_300)
+      rlmmWithTopicStorage.putRemoteLogSegmentData(rlSegIdTp2_401_700, rlSegMetTp2_401_700)
 
       val rlSegIdTp1_150 = rlmmWithTopicStorage.getRemoteLogSegmentId(tp1, 150)
-      Assert.assertEquals(rlSegIdTp1_101, rlSegIdTp1_150)
+      Assert.assertEquals(rlSegIdTp1_101_300, rlSegIdTp1_150)
 
       // this should return the RemoteLogSegmentId with highest offset as the target offset is beyond the highest.
       val rlSegIdTp0_300 = rlmmWithTopicStorage.getRemoteLogSegmentId(tp0, 300)
-      Assert.assertEquals(rlSegIdTp0_101, rlSegIdTp0_300)
+      Assert.assertEquals(rlSegIdTp0_101_200, rlSegIdTp0_300)
     } finally {
       mayBeRlmmWithTopicStorage.foreach(x => x.close())
     }
@@ -97,7 +113,7 @@ class RLMMWithTopicStorageTest extends IntegrationTestHarness {
     val rlmmWithTopicStorageReloaded = createRLMMWithTopicStorage(tmpLogDirPathAsStr)
     try {
       val remoteLogSegmentId170 = rlmmWithTopicStorageReloaded.getRemoteLogSegmentId(tp0, 170)
-      Assert.assertEquals(rlSegIdTp0_101, remoteLogSegmentId170)
+      Assert.assertEquals(rlSegIdTp0_101_200, remoteLogSegmentId170)
     } finally {
       rlmmWithTopicStorageReloaded.close()
     }
@@ -107,22 +123,22 @@ class RLMMWithTopicStorageTest extends IntegrationTestHarness {
   @throws[Exception]
   def testNonExistingOffsets(): Unit = {
 
-    val rlSegIdTp0_0 = new RemoteLogSegmentId(tp0, UUID.randomUUID)
-    val rlSegMetTp0_0 = new RemoteLogSegmentMetadata(rlSegIdTp0_0, 10L, 100L, -1L, 1, tp0.toString.getBytes)
+    val rlSegIdTp0_10 = new RemoteLogSegmentId(tp0, UUID.randomUUID)
+    val rlSegMetTp0_10 = new RemoteLogSegmentMetadata(rlSegIdTp0_10, 10L, 100L, -1L, 1, context)
     var mayBeRlmmWithTopicStorage: Option[RLMMWithTopicStorage] = None
     try {
-      mayBeRlmmWithTopicStorage = Some(createRLMMWithTopicStorage(tmpLogDirPathAsStr, 1))
-      val rlmmWithTopicStorage = mayBeRlmmWithTopicStorage.get
+      val rlmmWithTopicStorage = createRLMMWithTopicStorage(tmpLogDirPathAsStr, 1)
+      mayBeRlmmWithTopicStorage = Some(rlmmWithTopicStorage)
       rlmmWithTopicStorage.onPartitionLeadershipChanges(allTopicPartitions, Set.empty[TopicPartition].asJava)
-      rlmmWithTopicStorage.putRemoteLogSegmentData(rlSegIdTp0_0, rlSegMetTp0_0)
+      rlmmWithTopicStorage.putRemoteLogSegmentData(rlSegIdTp0_10, rlSegMetTp0_10)
 
       // get the non existing offset, below base offset
-      val remoteLogSegmentId2 = rlmmWithTopicStorage.getRemoteLogSegmentId(tp0, 2L)
-      Assert.assertNull(remoteLogSegmentId2)
+      val rlSegIdTp0_2 = rlmmWithTopicStorage.getRemoteLogSegmentId(tp0, 2L)
+      Assert.assertNull(rlSegIdTp0_2)
 
       // get the non existing offset, above end offset. This should return the immediate floor entry.
-      val remoteLogSegmentId200 = rlmmWithTopicStorage.getRemoteLogSegmentId(tp0, 200L)
-      Assert.assertEquals(rlSegIdTp0_0, remoteLogSegmentId200)
+      val rlSegIdTp0_200 = rlmmWithTopicStorage.getRemoteLogSegmentId(tp0, 200L)
+      Assert.assertEquals(rlSegIdTp0_10, rlSegIdTp0_200)
     } finally {
       mayBeRlmmWithTopicStorage.foreach(x => x.close())
     }
@@ -131,23 +147,21 @@ class RLMMWithTopicStorageTest extends IntegrationTestHarness {
   @Test
   @throws[Exception]
   def testDeleteRemoteLogSegment(): Unit = {
-    val rlSegIdTp0_0 = new RemoteLogSegmentId(tp0, UUID.randomUUID)
-    val rlSegMetTp0_0 = new RemoteLogSegmentMetadata(rlSegIdTp0_0, 10L, 100L, -1L, 1, tp0.toString.getBytes)
 
     var mayBeRlmmWithTopicStorage: Option[RLMMWithTopicStorage] = None
 
     try {
-      mayBeRlmmWithTopicStorage = Some(createRLMMWithTopicStorage(tmpLogDirPathAsStr, 1))
-      val rlmmWithTopicStorage = mayBeRlmmWithTopicStorage.get
+      val rlmmWithTopicStorage = createRLMMWithTopicStorage(tmpLogDirPathAsStr, 1)
+      mayBeRlmmWithTopicStorage = Some(rlmmWithTopicStorage)
       rlmmWithTopicStorage.onPartitionLeadershipChanges(allTopicPartitions, Set.empty[TopicPartition].asJava)
-      rlmmWithTopicStorage.putRemoteLogSegmentData(rlSegIdTp0_0, rlSegMetTp0_0)
+      rlmmWithTopicStorage.putRemoteLogSegmentData(rlSegIdTp0_0_100, rlSegMetTp0_0_100)
 
       // get the non existing offset, below base offset
       val rlSegMetTp0_15 = rlmmWithTopicStorage.getRemoteLogSegmentId(tp0, 15L)
-      Assert.assertEquals(rlSegIdTp0_0, rlSegMetTp0_15)
+      Assert.assertEquals(rlSegIdTp0_0_100, rlSegMetTp0_15)
 
       // delete the segment
-      rlmmWithTopicStorage.deleteRemoteLogSegmentMetadata(rlSegIdTp0_0)
+      rlmmWithTopicStorage.deleteRemoteLogSegmentMetadata(rlSegIdTp0_0_100)
 
       // there should not be any entry as it is already deleted.
       val rlSegMetTp0_15_2 = rlmmWithTopicStorage.getRemoteLogSegmentId(tp0, 15L)
@@ -160,72 +174,177 @@ class RLMMWithTopicStorageTest extends IntegrationTestHarness {
 
   private def createRLMMWithTopicStorage(tmpLogDirPath: String, brokerId: Int = 1): RLMMWithTopicStorage = {
     val rlmmWithTopicStorage = new RLMMWithTopicStorage
+    configureRLMM(tmpLogDirPath, brokerId, rlmmWithTopicStorage)
+    rlmmWithTopicStorage
+  }
+
+  private def configureRLMM(tmpLogDirPath: String, brokerId: Int,
+                            rlmmWithTopicStorage: RLMMWithTopicStorage) = {
     val configs = new util.HashMap[String, Any]
-    configs.put("log.dir", tmpLogDirPath)
+    val logDir = new File(tmpLogDirPath, 1.toString)
+    logDir.mkdirs()
+    configs.put("log.dir", logDir.toString)
     configs.put(RemoteLogMetadataManager.BROKER_ID, brokerId)
     configs.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, brokerList)
     rlmmWithTopicStorage.configure(configs)
     rlmmWithTopicStorage.onServerStarted()
+  }
 
-    rlmmWithTopicStorage
+  def waitTillReceiveExpected(fn: () => RemoteLogSegmentId, expected: RemoteLogSegmentId, waitTimeInMillis:Long = 30000): Boolean = {
+    var checkAgain = true
+    val startTime = System.currentTimeMillis()
+    while (checkAgain) {
+      val result = fn()
+      if(!expected.equals(result)) {
+        if (System.currentTimeMillis() - startTime < waitTimeInMillis) {
+          info("Sleeping for 100 msecs to retry again")
+          Thread.sleep(100)
+          checkAgain = true
+        } else {
+          return false
+        }
+      } else {
+        return true
+      }
+    }
+
+    false
   }
 
   @Test
   @throws[Exception]
   def testMultipleRLMMInstanceWorkflow(): Unit = {
-    //todo-tier
-    val tp = Range.inclusive(0, 2).map(x => new TopicPartition("foo", x))
-
     // Multiple RLMM instances publishes events and they should receive events from each other.
 
+    // this is a leader and publishes remote log segment events.
+    val brokerId1 = 1
+    var mayBeRlmm1: Option[RLMMWithTopicStorage] = None
+
+    // this is a follower and never publishes events but consumes events from the topic.
+    val brokerId2 = 2
+    var mayBeRlmm2: Option[RLMMWithTopicStorage] = None
+
+    try {
+      val rlmm1 = createRLMMWithTopicStorage(tmpLogDirPathAsStr, brokerId1)
+      mayBeRlmm1 = Some(rlmm1)
+
+      val rlmm2 = createRLMMWithTopicStorage(tmpLogDirPathAsStr, brokerId2)
+      mayBeRlmm2 = Some(rlmm2);
+
+      // make tp0 and tp3 as leader for rlmm1 and follower for rlmm2
+      val partitions = new util.HashSet[TopicPartition]()
+      partitions.add(tp0)
+      partitions.add(tp2)
+      rlmm1.onPartitionLeadershipChanges(partitions, Collections.emptySet());
+
+      rlmm2.onPartitionLeadershipChanges(Collections.emptySet(), partitions);
+
+      // publishes events to rlmm1 for tp0 and tp2
+      rlmm1.putRemoteLogSegmentData(rlSegIdTp0_0_100, rlSegMetTp0_0_100);
+      rlmm1.putRemoteLogSegmentData(rlSegIdTp0_101_200, rlSegMetTp0_101_200);
+      rlmm1.putRemoteLogSegmentData(rlSegIdTp2_501_1000, rlSegMetTp2_501_1000);
+
+      // check whether the published events from rlmm1 are available.
+      val rlSegMetTp0_0_1 = rlmm1.getRemoteLogSegmentId(tp0, 10);
+      Assert.assertEquals(rlSegIdTp0_0_100, rlSegMetTp0_0_1);
+      val rlSegIdTp0_101_1 = rlmm1.getRemoteLogSegmentId(tp0, 190);
+      Assert.assertEquals(rlSegIdTp0_101_200, rlSegIdTp0_101_1);
+
+      // check whether these events are received in rlmm2 as it is a follower.
+      Assert.assertTrue(waitTillReceiveExpected(() => rlmm2.getRemoteLogSegmentId(tp0, 10), rlSegIdTp0_0_100))
+      Assert.assertTrue(waitTillReceiveExpected(() => rlmm2.getRemoteLogSegmentId(tp0, 190), rlSegIdTp0_101_200))
+
+    } finally {
+      mayBeRlmm1.foreach(x => x.close())
+      mayBeRlmm2.foreach(x => x.close())
+    }
   }
 
   @Test
   def testLeaderFollowerFailover(): Unit = {
 
     val brokerId1 = 1
-    val logDirs1 = new File(tmpLogDirPath.toFile, brokerId1.toString)
-    logDirs1.mkdirs()
     var mayBeRlmm1: Option[RLMMWithTopicStorage] = None
 
     val brokerId2 = 2
-    val logDirs2 = new File(tmpLogDirPath.toFile, brokerId2.toString)
-    logDirs2.mkdirs()
     var mayBeRlmm2: Option[RLMMWithTopicStorage] = None
 
+    // tp3 remote log segment metadata notifications always go to partition 1 and all other notifications go to
+    //partition 0.
+    class RLMMWithTopicStorageWithCustomPartitioner extends RLMMWithTopicStorage {
+      override def metadataPartitionFor(tp: TopicPartition): Int = {
+        if(tp.equals(tp3)) 1 else 0
+      }
+    }
+
     try {
-      mayBeRlmm1 = Some(createRLMMWithTopicStorage(logDirs1.getAbsolutePath, brokerId1));
-      val rlmm1 = mayBeRlmm1.get
-      // make tp0 and tp3 as leader for rlmm1, and tp1 follower for rlmm1
+      val rlmm1 = new RLMMWithTopicStorageWithCustomPartitioner()
+
+      mayBeRlmm1 = Some(rlmm1)
+      configureRLMM(tmpLogDirPathAsStr, brokerId1, rlmm1)
+
+      // make tp0 and tp3 as leader for rlmm1
       val leaderSet1 = new util.HashSet[TopicPartition]()
       leaderSet1.add(tp0)
       leaderSet1.add(tp3)
-      rlmm1.onPartitionLeadershipChanges(leaderSet1, Collections.singleton(tp1))
+      rlmm1.onPartitionLeadershipChanges(leaderSet1, Collections.emptySet())
 
-      val rlSegIdTp0_0 = new RemoteLogSegmentId(tp0, UUID.randomUUID)
-      val rlSegMetTp0_0 = new RemoteLogSegmentMetadata(rlSegIdTp0_0, 0L, 100L, -1L, 1, tp0.toString.getBytes)
+      // publish segment metadata
+      rlmm1.putRemoteLogSegmentData(rlSegIdTp0_0_100, rlSegMetTp0_0_100)
+      rlmm1.putRemoteLogSegmentData(rlSegIdTp0_101_200, rlSegMetTp0_101_200)
+      rlmm1.putRemoteLogSegmentData(rlSegIdTp3_101_700, rlSegMetTp3_101)
 
-      val rlSegIdTp0_101 = new RemoteLogSegmentId(tp0, UUID.randomUUID)
-      val rlSegMetTp0_101 = new RemoteLogSegmentMetadata(rlSegIdTp0_101, 101L, 200L, -1L, 1, tp0.toString.getBytes)
+      val rlSegMetTp0_10 = rlmm1.getRemoteLogSegmentId(tp0, 10);
+      Assert.assertEquals(rlSegIdTp0_0_100, rlSegMetTp0_10);
 
-      val rlSegIdTp3_101 = new RemoteLogSegmentId(tp3, UUID.randomUUID)
-      val rlSegMetTp3_101 = new RemoteLogSegmentMetadata(rlSegIdTp3_101, 101L, 200L, -1L, 1, tp3.toString.getBytes)
+      val rlSegMetTp3_140 = rlmm1.getRemoteLogSegmentId(tp3, 140);
+      Assert.assertEquals(rlSegIdTp3_101_700, rlSegMetTp3_140);
+
+      val rlmm2 = new RLMMWithTopicStorageWithCustomPartitioner()
+      mayBeRlmm2 = Some(rlmm2)
+      configureRLMM(tmpLogDirPathAsStr, brokerId2, rlmm2)
 
       // make tp1 and tp2 as leaders for rlmm2
       val leaderSet2 = new util.HashSet[TopicPartition]()
       leaderSet2.add(tp1)
       leaderSet2.add(tp2)
-      mayBeRlmm2 = Some(createRLMMWithTopicStorage(logDirs2.getAbsolutePath, brokerId2))
-      val rlmm2 = mayBeRlmm2.get
       rlmm2.onPartitionLeadershipChanges(leaderSet2, Collections.emptySet())
 
-      // reassign tp0 from rlmm1 to rlmm2. rlmm1 should not receive any updates of tp0 as it should have been
-      // unsubscribed.
+      // publish segment metadata
+      rlmm2.putRemoteLogSegmentData(rlSegIdTp1_101_300, rlSegMetTp1_101_300)
+      rlmm2.putRemoteLogSegmentData(rlSegIdTp2_150_400, rlSegMetTp2_150_400)
 
+      // check for a few messages for tp1 and tp2 but not for tp0
+      val rlSegIdTp1_180 = rlmm2.getRemoteLogSegmentId(tp1, 180)
+      Assert.assertEquals(rlSegIdTp1_101_300, rlSegIdTp1_180)
 
-      // change follower of tp1 from rlmm1 to rlmm2
+      val rlSegIdTp2_300 = rlmm2.getRemoteLogSegmentId(tp2, 300)
+      Assert.assertEquals(rlSegIdTp2_150_400, rlSegIdTp2_300)
 
-      // make tp3 as follower in rlmm1 and leadership to rlmm2.
+      // check for tp3 messages in rlmm2, but it should not have received
+      Assert.assertFalse(waitTillReceiveExpected(() => rlmm2.getRemoteLogSegmentId(tp3, 170), rlSegIdTp3_101_700, 2000L));
+
+      // reassign tp3 from rlmm1 to rlmm2. rlmm1 should not receive any updates of tp3 as it should have been
+      // unsubscribed fro remote log metadata partition 1. Because only tp3 notifications go to partition 1.
+      leaderSet1.remove(tp3)
+      rlmm1.onPartitionLeadershipChanges(leaderSet1, Collections.emptySet())
+      leaderSet2.add(tp3)
+      rlmm2.onPartitionLeadershipChanges(leaderSet2, Collections.emptySet())
+
+      // rlmm2 should receive all notifications for tp3 as it is subscribed for.
+      Assert.assertTrue(waitTillReceiveExpected(() => rlmm2.getRemoteLogSegmentId(tp3, 170), rlSegIdTp3_101_700));
+
+      // add a new segment notification for tp3
+      rlmm2.putRemoteLogSegmentData(rlSegIdTp3_701_1900, rlSegMetTp3_701_1900)
+      Assert.assertTrue(waitTillReceiveExpected(() => rlmm2.getRemoteLogSegmentId(tp3, 720), rlSegIdTp3_701_1900));
+
+      // rlmm1 should not receive latest tp3 segment notifications as it is not assigned for.
+      Assert.assertFalse(waitTillReceiveExpected(() => rlmm1.getRemoteLogSegmentId(tp3, 720), rlSegIdTp3_701_1900, 2000L));
+
+      // add rlmm1 as follower for tp3 and it should receive the latest tp3 segment notification.
+      rlmm1.onPartitionLeadershipChanges(leaderSet1, Collections.singleton(tp3))
+      Assert.assertTrue(waitTillReceiveExpected(() => rlmm1.getRemoteLogSegmentId(tp3, 720), rlSegIdTp3_701_1900));
+
     } finally {
       mayBeRlmm1.foreach(x => x.close())
       mayBeRlmm2.foreach(x => x.close())

--- a/core/src/test/scala/unit/kafka/log/remote/RLMMWithTopicStorageTest.scala
+++ b/core/src/test/scala/unit/kafka/log/remote/RLMMWithTopicStorageTest.scala
@@ -24,7 +24,8 @@ import java.util.{Collections, UUID}
 import kafka.api.IntegrationTestHarness
 import org.apache.kafka.clients.CommonClientConfigs
 import org.apache.kafka.common.TopicPartition
-import org.apache.kafka.common.log.remote.storage.{RLMMWithTopicStorage, RemoteLogMetadataManager, RemoteLogSegmentId, RemoteLogSegmentMetadata}
+import org.apache.kafka.common.log.remote.metadata.storage.RLMMWithTopicStorage
+import org.apache.kafka.common.log.remote.storage.{RemoteLogMetadataManager, RemoteLogSegmentId, RemoteLogSegmentMetadata}
 import org.junit.{Assert, Before, Test}
 
 import scala.collection.JavaConverters._


### PR DESCRIPTION
 - Added serdes for the messages stored in remote log metadata topic with internal protocol schema
 - Refactored RLMMWithTopicStorage to be more modular.
 - Added RemoteLogSegmentMetadata ser/des for storing the snapshot of the received messages from remote log metadata topic.
 - Added tests for RLMM on leader and follower events from remote log metadata topic.