### PR TITLE
Fix several bugs related with remote log segment reading

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/record/RemoteLogInputStream.java
+++ b/clients/src/main/java/org/apache/kafka/common/record/RemoteLogInputStream.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.record;
+
+import org.apache.kafka.common.errors.CorruptRecordException;
+import org.apache.kafka.common.utils.Utils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+
+import static org.apache.kafka.common.record.Records.HEADER_SIZE_UP_TO_MAGIC;
+import static org.apache.kafka.common.record.Records.LOG_OVERHEAD;
+import static org.apache.kafka.common.record.Records.MAGIC_OFFSET;
+import static org.apache.kafka.common.record.Records.OFFSET_OFFSET;
+import static org.apache.kafka.common.record.Records.SIZE_OFFSET;
+
+public class RemoteLogInputStream implements LogInputStream<RecordBatch> {
+    private InputStream is;
+    private final ByteBuffer logHeaderBuffer = ByteBuffer.allocate(HEADER_SIZE_UP_TO_MAGIC);
+
+    public RemoteLogInputStream(InputStream is) {
+        this.is = is;
+    }
+
+    @Override
+    public RecordBatch nextBatch() throws IOException {
+        logHeaderBuffer.rewind();
+        Utils.readFully(is, logHeaderBuffer);
+
+        if (logHeaderBuffer.position() < HEADER_SIZE_UP_TO_MAGIC)
+            return null;
+
+        logHeaderBuffer.rewind();
+        long offset = logHeaderBuffer.getLong(OFFSET_OFFSET);
+        int size = logHeaderBuffer.getInt(SIZE_OFFSET);
+
+        // V0 has the smallest overhead, stricter checking is done later
+        if (size < LegacyRecord.RECORD_OVERHEAD_V0)
+            throw new CorruptRecordException(String.format("Found record size %d smaller than minimum record " +
+                "overhead (%d).", size, LegacyRecord.RECORD_OVERHEAD_V0));
+
+        byte magic = logHeaderBuffer.get(MAGIC_OFFSET);
+        ByteBuffer buffer = ByteBuffer.allocate(size + LOG_OVERHEAD);
+        System.arraycopy(logHeaderBuffer.array(), 0, buffer.array(), 0, logHeaderBuffer.limit());
+        buffer.position(logHeaderBuffer.limit());
+
+        Utils.readFully(is, buffer);
+        if (buffer.position() != size + LOG_OVERHEAD)
+            return null;
+        buffer.rewind();
+
+        MutableRecordBatch batch;
+        if (magic > RecordBatch.MAGIC_VALUE_V1)
+            batch = new DefaultRecordBatch(buffer);
+        else
+            batch = new AbstractLegacyRecordBatch.ByteBufferLegacyRecordBatch(buffer);
+
+        return batch;
+    }
+}

--- a/clients/src/test/java/org/apache/kafka/common/record/RemoteLogInputStreamTest.java
+++ b/clients/src/test/java/org/apache/kafka/common/record/RemoteLogInputStreamTest.java
@@ -1,0 +1,252 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kafka.common.record;
+
+import org.apache.kafka.test.TestUtils;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static org.apache.kafka.common.record.RecordBatch.MAGIC_VALUE_V0;
+import static org.apache.kafka.common.record.RecordBatch.MAGIC_VALUE_V1;
+import static org.apache.kafka.common.record.RecordBatch.MAGIC_VALUE_V2;
+import static org.apache.kafka.common.record.RecordBatch.NO_TIMESTAMP;
+import static org.apache.kafka.common.record.TimestampType.CREATE_TIME;
+import static org.apache.kafka.common.record.TimestampType.NO_TIMESTAMP_TYPE;
+import static org.apache.kafka.test.TestUtils.tempFile;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(value = Parameterized.class)
+public class RemoteLogInputStreamTest {
+    private final byte magic;
+    private final CompressionType compression;
+
+    public RemoteLogInputStreamTest(byte magic, CompressionType compression) {
+        this.magic = magic;
+        this.compression = compression;
+    }
+
+    @Test
+    public void testSimpleBatchIteration() throws IOException {
+        if (compression == CompressionType.ZSTD && magic < MAGIC_VALUE_V2)
+            return;
+
+        SimpleRecord firstBatchRecord = new SimpleRecord(3241324L, "a".getBytes(), "foo".getBytes());
+        SimpleRecord secondBatchRecord = new SimpleRecord(234280L, "b".getBytes(), "bar".getBytes());
+
+        File file = tempFile();
+        try (FileRecords fileRecords = FileRecords.open(file)) {
+            fileRecords.append(MemoryRecords.withRecords(magic, 0L, compression, CREATE_TIME, firstBatchRecord));
+            fileRecords.append(MemoryRecords.withRecords(magic, 1L, compression, CREATE_TIME, secondBatchRecord));
+            fileRecords.flush();
+        }
+
+        try (FileInputStream is = new FileInputStream(file)) {
+            RemoteLogInputStream logInputStream = new RemoteLogInputStream(is);
+
+            RecordBatch firstBatch = logInputStream.nextBatch();
+            assertGenericRecordBatchData(firstBatch, 0L, 3241324L, firstBatchRecord);
+            assertNoProducerData(firstBatch);
+
+            RecordBatch secondBatch = logInputStream.nextBatch();
+            assertGenericRecordBatchData(secondBatch, 1L, 234280L, secondBatchRecord);
+            assertNoProducerData(secondBatch);
+
+            assertNull(logInputStream.nextBatch());
+        }
+    }
+
+    @Test
+    public void testBatchIterationWithMultipleRecordsPerBatch() throws IOException {
+        if (magic < MAGIC_VALUE_V2 && compression == CompressionType.NONE)
+            return;
+
+        if (compression == CompressionType.ZSTD && magic < MAGIC_VALUE_V2)
+            return;
+
+        SimpleRecord[] firstBatchRecords = new SimpleRecord[]{
+            new SimpleRecord(3241324L, "a".getBytes(), "1".getBytes()),
+            new SimpleRecord(234280L, "b".getBytes(), "2".getBytes())
+        };
+
+        SimpleRecord[] secondBatchRecords = new SimpleRecord[]{
+            new SimpleRecord(238423489L, "c".getBytes(), "3".getBytes()),
+            new SimpleRecord(897839L, null, "4".getBytes()),
+            new SimpleRecord(8234020L, "e".getBytes(), null)
+        };
+
+        File file = tempFile();
+        try (FileRecords fileRecords = FileRecords.open(file)) {
+            fileRecords.append(MemoryRecords.withRecords(magic, 0L, compression, CREATE_TIME, firstBatchRecords));
+            fileRecords.append(MemoryRecords.withRecords(magic, 1L, compression, CREATE_TIME, secondBatchRecords));
+            fileRecords.flush();
+        }
+
+        try (FileInputStream is = new FileInputStream(file)) {
+            RemoteLogInputStream logInputStream = new RemoteLogInputStream(is);
+
+            RecordBatch firstBatch = logInputStream.nextBatch();
+            assertNoProducerData(firstBatch);
+            assertGenericRecordBatchData(firstBatch, 0L, 3241324L, firstBatchRecords);
+
+            RecordBatch secondBatch = logInputStream.nextBatch();
+            assertNoProducerData(secondBatch);
+            assertGenericRecordBatchData(secondBatch, 1L, 238423489L, secondBatchRecords);
+
+            assertNull(logInputStream.nextBatch());
+        }
+    }
+
+    @Test
+    public void testBatchIterationV2() throws IOException {
+        if (magic != MAGIC_VALUE_V2)
+            return;
+
+        long producerId = 83843L;
+        short producerEpoch = 15;
+        int baseSequence = 234;
+        int partitionLeaderEpoch = 9832;
+
+        SimpleRecord[] firstBatchRecords = new SimpleRecord[]{
+            new SimpleRecord(3241324L, "a".getBytes(), "1".getBytes()),
+            new SimpleRecord(234280L, "b".getBytes(), "2".getBytes())
+        };
+
+        SimpleRecord[] secondBatchRecords = new SimpleRecord[]{
+            new SimpleRecord(238423489L, "c".getBytes(), "3".getBytes()),
+            new SimpleRecord(897839L, null, "4".getBytes()),
+            new SimpleRecord(8234020L, "e".getBytes(), null)
+        };
+
+        File file = tempFile();
+        try (FileRecords fileRecords = FileRecords.open(file)) {
+            fileRecords.append(MemoryRecords.withIdempotentRecords(magic, 15L, compression, producerId,
+                producerEpoch, baseSequence, partitionLeaderEpoch, firstBatchRecords));
+            fileRecords.append(MemoryRecords.withTransactionalRecords(magic, 27L, compression, producerId,
+                producerEpoch, baseSequence + firstBatchRecords.length, partitionLeaderEpoch, secondBatchRecords));
+            fileRecords.flush();
+        }
+
+        try (FileInputStream is = new FileInputStream(file)) {
+            RemoteLogInputStream logInputStream = new RemoteLogInputStream(is);
+
+            RecordBatch firstBatch = logInputStream.nextBatch();
+            assertProducerData(firstBatch, producerId, producerEpoch, baseSequence, false, firstBatchRecords);
+            assertGenericRecordBatchData(firstBatch, 15L, 3241324L, firstBatchRecords);
+            assertEquals(partitionLeaderEpoch, firstBatch.partitionLeaderEpoch());
+
+            RecordBatch secondBatch = logInputStream.nextBatch();
+            assertProducerData(secondBatch, producerId, producerEpoch, baseSequence + firstBatchRecords.length,
+                true, secondBatchRecords);
+            assertGenericRecordBatchData(secondBatch, 27L, 238423489L, secondBatchRecords);
+            assertEquals(partitionLeaderEpoch, secondBatch.partitionLeaderEpoch());
+
+            assertNull(logInputStream.nextBatch());
+        }
+    }
+
+    @Test
+    public void testBatchIterationIncompleteBatch() throws IOException {
+        if (compression == CompressionType.ZSTD && magic < MAGIC_VALUE_V2)
+            return;
+
+        try (FileRecords fileRecords = FileRecords.open(tempFile())) {
+            SimpleRecord firstBatchRecord = new SimpleRecord(100L, "foo".getBytes());
+            SimpleRecord secondBatchRecord = new SimpleRecord(200L, "bar".getBytes());
+
+            fileRecords.append(MemoryRecords.withRecords(magic, 0L, compression, CREATE_TIME, firstBatchRecord));
+            fileRecords.append(MemoryRecords.withRecords(magic, 1L, compression, CREATE_TIME, secondBatchRecord));
+            fileRecords.flush();
+            fileRecords.truncateTo(fileRecords.sizeInBytes() - 13);
+
+            FileLogInputStream logInputStream = new FileLogInputStream(fileRecords, 0, fileRecords.sizeInBytes());
+
+            FileLogInputStream.FileChannelRecordBatch firstBatch = logInputStream.nextBatch();
+            assertNoProducerData(firstBatch);
+            assertGenericRecordBatchData(firstBatch, 0L, 100L, firstBatchRecord);
+
+            assertNull(logInputStream.nextBatch());
+        }
+    }
+
+    private void assertProducerData(RecordBatch batch, long producerId, short producerEpoch, int baseSequence,
+                                    boolean isTransactional, SimpleRecord... records) {
+        assertEquals(producerId, batch.producerId());
+        assertEquals(producerEpoch, batch.producerEpoch());
+        assertEquals(baseSequence, batch.baseSequence());
+        assertEquals(baseSequence + records.length - 1, batch.lastSequence());
+        assertEquals(isTransactional, batch.isTransactional());
+    }
+
+    private void assertNoProducerData(RecordBatch batch) {
+        assertEquals(RecordBatch.NO_PRODUCER_ID, batch.producerId());
+        assertEquals(RecordBatch.NO_PRODUCER_EPOCH, batch.producerEpoch());
+        assertEquals(RecordBatch.NO_SEQUENCE, batch.baseSequence());
+        assertEquals(RecordBatch.NO_SEQUENCE, batch.lastSequence());
+        assertFalse(batch.isTransactional());
+    }
+
+    private void assertGenericRecordBatchData(RecordBatch batch, long baseOffset, long maxTimestamp, SimpleRecord... records) {
+        assertEquals(magic, batch.magic());
+        assertEquals(compression, batch.compressionType());
+
+        if (magic == MAGIC_VALUE_V0) {
+            assertEquals(NO_TIMESTAMP_TYPE, batch.timestampType());
+        } else {
+            assertEquals(CREATE_TIME, batch.timestampType());
+            assertEquals(maxTimestamp, batch.maxTimestamp());
+        }
+
+        assertEquals(baseOffset + records.length - 1, batch.lastOffset());
+        if (magic >= MAGIC_VALUE_V2)
+            assertEquals(Integer.valueOf(records.length), batch.countOrNull());
+
+        assertEquals(baseOffset, batch.baseOffset());
+        assertTrue(batch.isValid());
+
+        List<Record> batchRecords = TestUtils.toList(batch);
+        for (int i = 0; i < records.length; i++) {
+            assertEquals(baseOffset + i, batchRecords.get(i).offset());
+            assertEquals(records[i].key(), batchRecords.get(i).key());
+            assertEquals(records[i].value(), batchRecords.get(i).value());
+            if (magic == MAGIC_VALUE_V0)
+                assertEquals(NO_TIMESTAMP, batchRecords.get(i).timestamp());
+            else
+                assertEquals(records[i].timestamp(), batchRecords.get(i).timestamp());
+        }
+    }
+
+    @Parameterized.Parameters(name = "magic={0}, compression={1}")
+    public static Collection<Object[]> data() {
+        List<Object[]> values = new ArrayList<>();
+        for (byte magic : asList(MAGIC_VALUE_V0, MAGIC_VALUE_V1, MAGIC_VALUE_V2))
+            for (CompressionType type : CompressionType.values())
+                values.add(new Object[]{magic, type});
+        return values;
+    }
+}

--- a/core/src/main/scala/kafka/log/remote/RemoteLogManager.scala
+++ b/core/src/main/scala/kafka/log/remote/RemoteLogManager.scala
@@ -35,7 +35,7 @@ import org.apache.kafka.common.errors.OffsetOutOfRangeException
 import org.apache.kafka.common.internals.Topic
 import org.apache.kafka.common.log.remote.storage.{ClassLoaderAwareRemoteLogMetadataManager, LogSegmentData, RemoteLogMetadataManager, RemoteLogSegmentId, RemoteLogSegmentMetadata, RemoteStorageManager}
 import org.apache.kafka.common.record.FileRecords.TimestampAndOffset
-import org.apache.kafka.common.record.MemoryRecords
+import org.apache.kafka.common.record.{MemoryRecords, RecordBatch, RemoteLogInputStream}
 import org.apache.kafka.common.requests.FetchRequest.PartitionData
 import org.apache.kafka.common.utils.{ChildFirstClassLoader, KafkaThread, Time, Utils}
 
@@ -433,41 +433,36 @@ class RemoteLogManager(fetchLog: TopicPartition => Option[Log],
     indexCache.position(remoteLogSegmentMetadata, offset).position
   }
 
-  def read(fetchMaxByes: Int, minOneMessage: Boolean, tp: TopicPartition, fetchInfo: PartitionData): FetchDataInfo = {
+  def read(fetchMaxBytes: Int, minOneMessage: Boolean, tp: TopicPartition, fetchInfo: PartitionData): FetchDataInfo = {
     val offset = fetchInfo.fetchOffset
-    val maxBytes = fetchInfo.maxBytes
+    val maxBytes = Math.min(fetchMaxBytes, fetchInfo.maxBytes)
+    val rlsMetadata = getRemoteLogSegmentMetadata(tp, offset)
 
-    // different cases to be considered to get the endPosition.
-    // endPosition can be with in this segment, else get the next segment till we runout of fetchMaxBytes.
-    def fetchRemoteLogSegmentInfo(maxBytes: Int, offset: Long): (RemoteLogSegmentMetadata, Long, Int, Long) = {
-      val rlsMetadata = getRemoteLogSegmentMetadata(tp, offset)
-      // todo-tier build offset index cache, get the index if it does not exist and get the position for the given
-      // offset.
-      val startPos = lookupPositionForOffset(rlsMetadata, offset)
-      val endSegOffset = rlsMetadata.endOffset()
-      val endSegPos = lookupPositionForOffset(rlsMetadata, endSegOffset)
-      val availableInSeg = (endSegPos - startPos).toInt
-      val len = math.min(maxBytes, availableInSeg)
-      (rlsMetadata, startPos, len, endSegOffset)
+    var startPos = lookupPositionForOffset(rlsMetadata, offset)
+    var is:InputStream = null
+    try {
+      // Search forward for the position of the last offset that is greater than or equal to the target offset
+      is = remoteLogStorageManager.fetchLogSegmentData(rlsMetadata, startPos, Int.MaxValue)
+      val logInputStream = new RemoteLogInputStream(is)
+
+      var batch:RecordBatch = null;
+      while ((batch = logInputStream.nextBatch()) != null && batch.lastOffset < offset) {
+        startPos += batch.sizeInBytes
+      }
+    } finally {
+      is.close()
     }
 
-    var totalLength: Int = 0
-    var streams: ListBuffer[InputStream] = new ListBuffer()
-    var availableBytes = fetchMaxByes
-    var nextOffset = offset
-    while (availableBytes > 0) {
-      val (rlsMetadata, startPos, len, endSegOffset) = fetchRemoteLogSegmentInfo(availableBytes, nextOffset)
-      val is = remoteLogStorageManager.fetchLogSegmentData(rlsMetadata, startPos, startPos + len)
-      streams += is
-      nextOffset = endSegOffset + 1
-      availableBytes -= len
-      totalLength += len
+    try {
+      is = remoteLogStorageManager.fetchLogSegmentData(rlsMetadata, startPos, startPos + maxBytes)
+      val buffer = ByteBuffer.allocate(fetchMaxBytes)
+      Utils.readFully(is, buffer)
+      buffer.flip()
+      val records = MemoryRecords.readableRecords(buffer)
+      FetchDataInfo(LogOffsetMetadata(offset), records)
+    } finally {
+      is.close()
     }
-
-    val buffer = ByteBuffer.allocate(totalLength)
-    streams.foreach(is => Utils.readFully(is, buffer))
-    val records = MemoryRecords.readableRecords(buffer)
-    FetchDataInfo(LogOffsetMetadata(offset), records)
   }
 
   private def getRemoteLogSegmentMetadata(tp: TopicPartition, offset: Long): RemoteLogSegmentMetadata = {

--- a/core/src/test/scala/unit/kafka/log/remote/RemoteLogReaderTest.scala
+++ b/core/src/test/scala/unit/kafka/log/remote/RemoteLogReaderTest.scala
@@ -130,7 +130,7 @@ class MockRemoteLogManager(threads: Int, taskQueueSize: Int)
     Files.createTempDirectory("kafka-test-").toString) {
   private val lock = new ReentrantReadWriteLock
 
-  override def read(fetchMaxByes: Int, minOneMessage: Boolean, tp: TopicPartition, fetchInfo: FetchRequest.PartitionData): FetchDataInfo = {
+  override def read(fetchMaxBytes: Int, minOneMessage: Boolean, tp: TopicPartition, fetchInfo: FetchRequest.PartitionData): FetchDataInfo = {
     lock.readLock.lock()
     try {
       val recordsArray = Array(new SimpleRecord("k1".getBytes, "v1".getBytes),


### PR DESCRIPTION
1. Offset index does not provide the exact position of the target offset in log segment. We have to read the log segment data and skip the batches before the target offset.

2. Either offset index and remote log segment metadata does not provide the remote log segment size. We have to rely on EOF of input stream to detect the end of remote segment. To do this, we have to write a new LogInputStream that directly reads data from InputStream (rather than ByteBuffer)

3. Do not try to read multiple remote segments in at once. The existing Kafka code only reads at most one local segment each time.



