### PR TITLE
Optimized RLM fetch to read only once from RSM to get the desired batch of messages.

### DIFF
--- a/core/src/main/scala/kafka/log/remote/RemoteLogReader.scala
+++ b/core/src/main/scala/kafka/log/remote/RemoteLogReader.scala
@@ -26,7 +26,7 @@ class RemoteLogReader(fetchInfo: RemoteStorageFetchInfo, rlm: RemoteLogManager, 
   override def execute(): Unit = {
     val result = {
       try {
-        val r = rlm.read(fetchInfo.fetchMaxByes, fetchInfo.minOneMessage, fetchInfo.topicPartition, fetchInfo.fetchInfo)
+        val r = rlm.read()
         RemoteLogReadResult(Some(r), None)
       } catch {
         case e: Exception =>

--- a/core/src/main/scala/kafka/server/FetchDataInfo.scala
+++ b/core/src/main/scala/kafka/server/FetchDataInfo.scala
@@ -33,7 +33,5 @@ case class FetchDataInfo(fetchOffsetMetadata: LogOffsetMetadata,
                          abortedTransactions: Option[List[AbortedTransaction]] = None,
                          delayedRemoteStorageFetch: Option[RemoteStorageFetchInfo] = None)
 
-case class RemoteStorageFetchInfo(fetchMaxByes: Int,
-                                  minOneMessage: Boolean,
-                                  topicPartition: TopicPartition,
-                                  fetchInfo: PartitionData)
+case class RemoteStorageFetchInfo(fetchMaxByes: Int, minOneMessage: Boolean, topicPartition: TopicPartition,
+                                  fetchInfo: PartitionData, fetchIsolation: FetchIsolation)

--- a/core/src/main/scala/kafka/server/ReplicaManager.scala
+++ b/core/src/main/scala/kafka/server/ReplicaManager.scala
@@ -1139,7 +1139,7 @@ class ReplicaManager(val config: KafkaConfig,
                 relativePositionInSegment = LogOffsetMetadata.UnknownFilePosition)
               FetchDataInfo(logOffsetMetadata, MemoryRecords.EMPTY,
                 delayedRemoteStorageFetch = Some(
-                  RemoteStorageFetchInfo(adjustedMaxBytes, minOneMessage, tp, fetchInfo)))
+                  RemoteStorageFetchInfo(adjustedMaxBytes, minOneMessage, tp, fetchInfo, fetchIsolation)))
             }
 
             LogReadResult(checkFetchDataInfo(tp, fetchDataInfo),

--- a/core/src/test/scala/unit/kafka/server/DelayedRemoteFetchTest.scala
+++ b/core/src/test/scala/unit/kafka/server/DelayedRemoteFetchTest.scala
@@ -81,7 +81,7 @@ class DelayedRemoteFetchTest extends EasyMockSupport {
   def RemoteFetch(timeout: Boolean, responseCallback: (Seq[(TopicPartition, FetchPartitionData)]) => Unit): Unit = {
     val rlm = new MockRemoteLogManager(5, 20)
     val fetchInfo = new PartitionData(100, 0, 1000, Optional.of(1))
-    val remoteFetchInfo = RemoteStorageFetchInfo(1000, true, tp, fetchInfo)
+    val remoteFetchInfo = RemoteStorageFetchInfo(1000, true, tp, fetchInfo, FetchTxnCommitted)
 
     val fetchPartitionStatus = FetchPartitionStatus(new LogOffsetMetadata(fetchInfo.fetchOffset), fetchInfo)
 


### PR DESCRIPTION
 - Optimized RLM fetch to read only once from RSM to get the desired batch of messages.