### PR TITLE
Fixed leadership changes of partitions in RLMM as updates only but not the complete set of partitions the broker hosted.

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/log/remote/metadata/storage/ConsumerTask.java
+++ b/clients/src/main/java/org/apache/kafka/common/log/remote/metadata/storage/ConsumerTask.java
@@ -39,6 +39,22 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
+/**
+ * This class is responsible for consuming messages from remote log metadata topic ({@link Topic#REMOTE_LOG_METADATA_TOPIC_NAME})
+ * partitions and maintain the state of the remote log segment metadata. It gives an API to add or remove
+ * for what topic partition's metadata should be consumed by this instance using
+ * {{@link #addAssignmentsForPartitions(Set)}} and {@link #removeAssignmentsForPartitions(Set)} respectively.
+ *
+ * When a broker is started, controller sends topic partitions that this broker is leader or follower for and the
+ * partitions to be deleted. This class receives those notifications with
+ * {@link #addAssignmentsForPartitions(Set)} and {@link #removeAssignmentsForPartitions(Set)} assigns consumer for the
+ * respective remote log metadata partitions by using {@link RemoteLogSegmentMetadataUpdater#metadataPartitionFor(TopicPartition)}.
+ * Any leadership changes later are called through the same API. We will remove the partitions that ard deleted from
+ * this broker which are received through {@link #removeAssignmentsForPartitions(Set)}. 
+ *
+ * After receiving these events it invokes {@link RemoteLogSegmentMetadataUpdater#updateRemoteLogSegmentMetadata(TopicPartition, RemoteLogSegmentMetadata)},
+ * which maintains inmemory representation of the state of {@link RemoteLogSegmentMetadata}.
+ */
 class ConsumerTask implements Runnable, Closeable {
     private static final Logger log = LoggerFactory.getLogger(ConsumerTask.class);
     private final KafkaConsumer<String, RemoteLogSegmentMetadata> consumer;
@@ -47,7 +63,7 @@ class ConsumerTask implements Runnable, Closeable {
 
     private final Object lock = new Object();
     private volatile Set<Integer> assignedMetaPartitions = Collections.emptySet();
-    private Set<TopicPartition> reassignedTopicPartitions;
+    private Set<TopicPartition> reassignedTopicPartitions = Collections.emptySet();;
 
     private volatile boolean closed = false;
     private volatile boolean reassign = false;
@@ -133,7 +149,7 @@ class ConsumerTask implements Runnable, Closeable {
                                 break;
                             } catch (Exception e) {
                                 // ignore exception
-                                log.info("#### Error encountered in fetching end offsets");
+                                log.info("Error encountered in fetching end offsets");
                             }
                         }
                         log.info("Fetched end offsets to consumer task [{}]", endOffsets);
@@ -209,29 +225,30 @@ class ConsumerTask implements Runnable, Closeable {
         }
     }
 
-    public void reassignForPartitions(Set<TopicPartition> partitions) {
-        Objects.requireNonNull(partitions, "partitions can not be null");
+    public void addAssignmentsForPartitions(Set<TopicPartition> updatedPartitions) {
+        Objects.requireNonNull(updatedPartitions, "partitions can not be null");
 
-        log.info("Reassigning for user partitions {}", partitions);
-        synchronized (lock) {
-            // check for the corresponding partitions.
-            Set<Integer> newlyAssignedPartitions = new HashSet<>();
-            for (TopicPartition tp : partitions) {
-                newlyAssignedPartitions.add(remoteLogSegmentMetadataUpdater.metadataPartitionFor(tp));
-            }
-            reassignedTopicPartitions = new HashSet<>(partitions);
-            assignedMetaPartitions = Collections.unmodifiableSet(newlyAssignedPartitions);
-            log.info("Newly assigned metadata partitions {}", assignedMetaPartitions);
-            reassign = true;
-
-            lock.notifyAll();
-        }
+        log.info("Reassigning for user partitions {}", updatedPartitions);
+        updateAssignmentsForPartitions(updatedPartitions, Collections.emptySet());
     }
 
     public void removeAssignmentsForPartitions(Set<TopicPartition> partitions) {
+        updateAssignmentsForPartitions(Collections.emptySet(), partitions);
+    }
+
+    private void updateAssignmentsForPartitions(Set<TopicPartition> addedPartitions,
+                                                Set<TopicPartition> removedPartitions) {
+        Objects.requireNonNull(addedPartitions,"addedPartitions must not be null");
+        Objects.requireNonNull(removedPartitions,"removedPartitions must not be null");
+
+        if(addedPartitions.isEmpty() && removedPartitions.isEmpty()) {
+            return;
+        }
+
         synchronized (lock) {
             Set<TopicPartition> updatedReassignedPartitions = new HashSet<>(reassignedTopicPartitions);
-            updatedReassignedPartitions.removeAll(partitions);
+            updatedReassignedPartitions.addAll(addedPartitions);
+            updatedReassignedPartitions.removeAll(removedPartitions);
             Set<Integer> updatedAssignedMetaPartitions = new HashSet<>();
             for (TopicPartition tp : updatedReassignedPartitions) {
                 updatedAssignedMetaPartitions.add(remoteLogSegmentMetadataUpdater.metadataPartitionFor(tp));

--- a/clients/src/main/java/org/apache/kafka/common/log/remote/metadata/storage/ConsumerTask.java
+++ b/clients/src/main/java/org/apache/kafka/common/log/remote/metadata/storage/ConsumerTask.java
@@ -149,7 +149,7 @@ class ConsumerTask implements Runnable, Closeable {
                                 break;
                             } catch (Exception e) {
                                 // ignore exception
-                                log.info("Error encountered in fetching end offsets");
+                                log.debug("Error encountered in fetching end offsets");
                             }
                         }
                         log.info("Fetched end offsets to consumer task [{}]", endOffsets);

--- a/core/src/main/scala/kafka/log/remote/RemoteLogManager.scala
+++ b/core/src/main/scala/kafka/log/remote/RemoteLogManager.scala
@@ -205,6 +205,8 @@ class RemoteLogManager(fetchLog: TopicPartition => Option[Log],
    */
   def onLeadershipChange(partitionsBecomeLeader: Set[Partition], partitionsBecomeFollower: Set[Partition]): Unit = {
 
+    debug(s"Received leadership changes for leaders:$partitionsBecomeLeader and followers: $partitionsBecomeFollower")
+
     // Partitions logs are available when this callback is invoked.
     // Compact topics and internal topics are filtered here as they are not supported with tiered storage.
     def filterPartitions(partitions: Set[Partition]): Set[Partition] = {
@@ -213,7 +215,12 @@ class RemoteLogManager(fetchLog: TopicPartition => Option[Log],
 
     val followerTopicPartitions = filterPartitions(partitionsBecomeFollower).map(p => p.topicPartition)
     val leaderPartitions = filterPartitions(partitionsBecomeLeader)
-    remoteLogMetadataManager.onPartitionLeadershipChanges(leaderPartitions.map(p => p.topicPartition).asJava, followerTopicPartitions.asJava)
+    val leaderTopicPartitions = leaderPartitions.map(p => p.topicPartition)
+
+    info(s"Effective topic partitions after filtering compact and internal topics, leaders: $leaderTopicPartitions " +
+      s"and followers: $followerTopicPartitions")
+
+    remoteLogMetadataManager.onPartitionLeadershipChanges(leaderTopicPartitions.asJava, followerTopicPartitions.asJava)
 
     followerTopicPartitions.foreach { tp => doHandleLeaderOrFollowerPartitions(tp, task => task.convertToFollower())}
 

--- a/core/src/main/scala/kafka/log/remote/RemoteLogManager.scala
+++ b/core/src/main/scala/kafka/log/remote/RemoteLogManager.scala
@@ -217,7 +217,7 @@ class RemoteLogManager(fetchLog: TopicPartition => Option[Log],
     val leaderPartitions = filterPartitions(partitionsBecomeLeader)
     val leaderTopicPartitions = leaderPartitions.map(p => p.topicPartition)
 
-    info(s"Effective topic partitions after filtering compact and internal topics, leaders: $leaderTopicPartitions " +
+    debug(s"Effective topic partitions after filtering compact and internal topics, leaders: $leaderTopicPartitions " +
       s"and followers: $followerTopicPartitions")
 
     remoteLogMetadataManager.onPartitionLeadershipChanges(leaderTopicPartitions.asJava, followerTopicPartitions.asJava)

--- a/core/src/test/scala/unit/kafka/log/remote/RLMMWithTopicStorageTest.scala
+++ b/core/src/test/scala/unit/kafka/log/remote/RLMMWithTopicStorageTest.scala
@@ -342,10 +342,10 @@ class RLMMWithTopicStorageTest extends IntegrationTestHarness {
 
       // reassign tp3 from rlmm1 to rlmm2. rlmm1 should not receive any updates of tp3 as it should have been
       // unsubscribed fro remote log metadata partition 1. Because only tp3 notifications go to partition 1.
-      leaderSet1.remove(tp3)
-      rlmm1.onPartitionLeadershipChanges(leaderSet1, Collections.emptySet())
-      leaderSet2.add(tp3)
-      rlmm2.onPartitionLeadershipChanges(leaderSet2, Collections.emptySet())
+
+      val movedPartitions = Collections.singleton(tp3)
+      rlmm1.onStopPartitions(movedPartitions)
+      rlmm2.onPartitionLeadershipChanges(movedPartitions, Collections.emptySet())
 
       // rlmm2 should receive all notifications for tp3 as it is subscribed for.
       Assert.assertTrue(waitTillReceiveExpected(() => rlmm2.getRemoteLogSegmentId(tp3, 170), rlSegIdTp3_101_700));
@@ -358,7 +358,7 @@ class RLMMWithTopicStorageTest extends IntegrationTestHarness {
       Assert.assertFalse(waitTillReceiveExpected(() => rlmm1.getRemoteLogSegmentId(tp3, 720), rlSegIdTp3_701_1900, 2000L));
 
       // add rlmm1 as follower for tp3 and it should receive the latest tp3 segment notification.
-      rlmm1.onPartitionLeadershipChanges(leaderSet1, Collections.singleton(tp3))
+      rlmm1.onPartitionLeadershipChanges(Collections.emptySet(), movedPartitions)
       Assert.assertTrue(waitTillReceiveExpected(() => rlmm1.getRemoteLogSegmentId(tp3, 720), rlSegIdTp3_701_1900));
 
     } finally {


### PR DESCRIPTION
Fixed leadership changes of partitions in RLMM as updates only but not the complete set of partitions the broker hosted.