### PR TITLE
Tiered storage tests

### DIFF
--- a/clients/src/test/java/org/apache/kafka/common/log/remote/storage/LocalTieredStorage.java
+++ b/clients/src/test/java/org/apache/kafka/common/log/remote/storage/LocalTieredStorage.java
@@ -155,7 +155,13 @@ public final class LocalTieredStorage implements RemoteStorageManager {
     public void traverse(final LocalTieredStorageTraverser traverser) {
         Objects.requireNonNull(traverser);
 
-        Arrays.stream(storageDirectory.listFiles())
+        final File[] files = storageDirectory.listFiles();
+        if (files == null) {
+            // files can be null if the directory is empty.
+            return;
+        }
+
+        Arrays.stream(files)
                 .filter(File::isDirectory)
                 .forEach(dir ->
                         openExistingTopicPartitionDirectory(dir.getName(), storageDirectory).traverse(traverser));

--- a/clients/src/test/java/org/apache/kafka/common/log/remote/storage/LocalTieredStorageEvent.java
+++ b/clients/src/test/java/org/apache/kafka/common/log/remote/storage/LocalTieredStorageEvent.java
@@ -21,6 +21,7 @@ import org.apache.kafka.common.TopicPartition;
 import java.util.Optional;
 
 import static java.lang.String.format;
+
 import static java.util.Objects.requireNonNull;
 import static java.util.Optional.ofNullable;
 

--- a/clients/src/test/java/org/apache/kafka/common/log/remote/storage/LocalTieredStorageEvent.java
+++ b/clients/src/test/java/org/apache/kafka/common/log/remote/storage/LocalTieredStorageEvent.java
@@ -21,7 +21,6 @@ import org.apache.kafka.common.TopicPartition;
 import java.util.Optional;
 
 import static java.lang.String.format;
-
 import static java.util.Objects.requireNonNull;
 import static java.util.Optional.ofNullable;
 

--- a/clients/src/test/java/org/apache/kafka/common/log/remote/storage/LocalTieredStorageSnapshot.java
+++ b/clients/src/test/java/org/apache/kafka/common/log/remote/storage/LocalTieredStorageSnapshot.java
@@ -64,6 +64,10 @@ public final class LocalTieredStorageSnapshot {
         return fileset.getFile(type);
     }
 
+    public String toString() {
+        return snapshot.records.values().stream().map(Object::toString).reduce("", (s1, s2) -> s1 + s2);
+    }
+
     private final Snapshot snapshot;
 
     private LocalTieredStorageSnapshot(final Snapshot snapshot) {

--- a/clients/src/test/java/org/apache/kafka/common/log/remote/storage/RemoteLogSegmentFileset.java
+++ b/clients/src/test/java/org/apache/kafka/common/log/remote/storage/RemoteLogSegmentFileset.java
@@ -29,6 +29,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.function.BinaryOperator;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -166,11 +168,6 @@ public final class RemoteLogSegmentFileset {
         return new RemoteLogSegmentFileset(tpDirectory, id, files);
     }
 
-
-    public RemoteTopicPartitionDirectory getPartitionDirectory() {
-        return partitionDirectory;
-    }
-
     public RemoteLogSegmentId getRemoteLogSegmentId() {
         return remoteLogSegmentId;
     }
@@ -193,6 +190,14 @@ public final class RemoteLogSegmentFileset {
         transferer.transfer(data.logSegment(), files.get(SEGMENT));
         transferer.transfer(data.offsetIndex(), files.get(OFFSET_INDEX));
         transferer.transfer(data.timeIndex(), files.get(TIME_INDEX));
+    }
+
+    public String toString() {
+        final String ls = files.values().stream()
+                .map(file -> "\t" + file.getName() + "\n")
+                .reduce("", (s1, s2) -> s1 + s2);
+
+        return format("%s/\n%s", partitionDirectory.getDirectory().getName(), ls);
     }
 
     public static boolean deleteFilesOnly(final Collection<File> files) {

--- a/core/src/main/scala/kafka/log/remote/RemoteLogManager.scala
+++ b/core/src/main/scala/kafka/log/remote/RemoteLogManager.scala
@@ -277,7 +277,7 @@ class RemoteLogManager(fetchLog: TopicPartition => Option[Log],
   }
 
   class RLMTask(tp: TopicPartition) extends CancellableRunnable with Logging {
-    this.logIdent = s"[RemoteLogManager=$brokerId partition=$tp ] "
+    this.logIdent = s"[RemoteLogManager=$brokerId partition=$tp] "
     @volatile private var leaderEpoch: Int = -1
 
     private def isLeader(): Boolean = leaderEpoch >= 0

--- a/core/src/test/scala/kafka/tiered/storage/LocalTieredStorageOutput.scala
+++ b/core/src/test/scala/kafka/tiered/storage/LocalTieredStorageOutput.scala
@@ -14,15 +14,20 @@ import scala.jdk.CollectionConverters._
 @nonthreadsafe
 final class LocalTieredStorageOutput[K, V](val keyDe: Deserializer[K],
                                            val valueDe: Deserializer[V]) extends LocalTieredStorageTraverser {
-
   private[storage] var output: String =
-    row("File", "Base offset", "End offset", "Base record", "End record", "")
+    row("File", "Base offset", "End offset", "First record", "Last record")
+
+  output += "-" * (55 + 12 + 12 + 13 + 13 + (4 * 2)) + "\n" // Columns length + 4 column separators.
+
+  private def row(c1: String = "", c2: Any = "", c3: Any = "", c4: String = "", c5: String = "", ident: String = " " * 4) = {
+    f"${ident + c1}%-55s |${c2.toString}%12s |${c3.toString}%12s |$c4%13s |$c5%13s\n"
+  }
 
   private var currentTopic: String = ""
 
   override def visitTopicPartition(topicPartition: TopicPartition): Unit = {
     currentTopic = topicPartition.topic()
-    output += s"$topicPartition/\n"
+    output += row(topicPartition.toString, ident = "")
   }
 
   override def visitSegment(fileset: RemoteLogSegmentFileset): Unit = {
@@ -53,10 +58,7 @@ final class LocalTieredStorageOutput[K, V](val keyDe: Deserializer[K],
 
     output += row(fileset.getFile(OFFSET_INDEX).getName)
     output += row(fileset.getFile(TIME_INDEX).getName)
-  }
-
-  private def row(c1: String, c2: Any = "", c3: Any = "", c4: String = "", c5: String = "", ident: String = "\t") = {
-    f"$ident$c1%-50s${c2.toString}%15s${c3.toString}%15s$c4%30s$c5%30s\n"
+    output += row()
   }
 }
 

--- a/core/src/test/scala/kafka/tiered/storage/LocalTieredStorageOutput.scala
+++ b/core/src/test/scala/kafka/tiered/storage/LocalTieredStorageOutput.scala
@@ -1,0 +1,71 @@
+package kafka.tiered.storage
+
+import java.nio.ByteBuffer
+
+import kafka.utils.nonthreadsafe
+import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.log.remote.storage.RemoteLogSegmentFileset.RemoteLogSegmentFileType.{OFFSET_INDEX, SEGMENT, TIME_INDEX}
+import org.apache.kafka.common.log.remote.storage.{LocalTieredStorage, LocalTieredStorageTraverser, RemoteLogSegmentFileset}
+import org.apache.kafka.common.serialization.Deserializer
+import org.apache.kafka.common.utils.Utils
+
+import scala.jdk.CollectionConverters._
+
+@nonthreadsafe
+final class LocalTieredStorageOutput[K, V](val keyDe: Deserializer[K],
+                                           val valueDe: Deserializer[V]) extends LocalTieredStorageTraverser {
+
+  private[storage] var output: String =
+    row("File", "Base offset", "End offset", "Base record", "End record", "")
+
+  private var currentTopic: String = ""
+
+  override def visitTopicPartition(topicPartition: TopicPartition): Unit = {
+    currentTopic = topicPartition.topic()
+    output += s"$topicPartition/\n"
+  }
+
+  override def visitSegment(fileset: RemoteLogSegmentFileset): Unit = {
+    val records = fileset.getRecords.asScala.toList
+    var (baseOffset, endOffset, baseKey, baseValue, endKey, endValue) = (-1L, -1L, "", "", "", "")
+
+    def des(de: Deserializer[_])(bytes: ByteBuffer): String = {
+      de.deserialize(currentTopic, Utils.toNullableArray(bytes)).toString
+    }
+
+    if (!records.isEmpty) {
+      val (head, tail) = (records.head, records.last)
+      baseOffset = head.offset()
+      baseKey = des(keyDe)(head.key())
+      baseValue = des(valueDe)(head.value())
+      endOffset = tail.offset()
+      endKey = des(keyDe)(tail.key())
+      endValue = des(valueDe)(tail.value())
+    }
+
+    output += row(
+      fileset.getFile(SEGMENT).getName,
+      baseOffset,
+      endOffset,
+      s"($baseKey, $baseValue)",
+      s"($endKey, $endValue)"
+    )
+
+    output += row(fileset.getFile(OFFSET_INDEX).getName)
+    output += row(fileset.getFile(TIME_INDEX).getName)
+  }
+
+  private def row(c1: String, c2: Any = "", c3: Any = "", c4: String = "", c5: String = "", ident: String = "\t") = {
+    f"$ident$c1%-50s${c2.toString}%15s${c3.toString}%15s$c4%30s$c5%30s\n"
+  }
+}
+
+object DumpLocalTieredStorage {
+
+  def dump[K, V](storage: LocalTieredStorage, keyDe: Deserializer[K], valueDe: Deserializer[V]): String = {
+    val output = new LocalTieredStorageOutput(keyDe, valueDe)
+    storage.traverse(output)
+    output.output
+  }
+
+}

--- a/core/src/test/scala/kafka/tiered/storage/TieredStorageTestHarness.scala
+++ b/core/src/test/scala/kafka/tiered/storage/TieredStorageTestHarness.scala
@@ -78,6 +78,8 @@ abstract class TieredStorageTestHarness extends IntegrationTestHarness {
     //
     overridingProps.setProperty(STORAGE_DIR_PROP, TestUtils.tempDir().getAbsolutePath)
 
+    overridingProps.setProperty(KafkaConfig.UncleanLeaderElectionEnableProp, true.toString)
+
     createBrokerConfigs(numConfigs = brokerCount, zkConnect).map(KafkaConfig.fromProps(_, overridingProps))
   }
 

--- a/core/src/test/scala/kafka/tiered/storage/TieredStorageTestSpec.scala
+++ b/core/src/test/scala/kafka/tiered/storage/TieredStorageTestSpec.scala
@@ -206,7 +206,12 @@ final class ProduceAction(val offloadedSegmentSpecs: Map[TopicPartition, Seq[Off
 
         localStorages
           //
-          // Filter out inactive brokers, which may contain deleted log segments.
+          // Select brokers which are assigned a replica of the topic-partition
+          //
+          .filter(s => context.isAssignedReplica(topicPartition, s.brokerId))
+          //
+          // Filter out inactive brokers, which may still contain log segments we would expect
+          // to be deleted based on the retention configuration.
           //
           .filter(s => context.isActive(s.brokerId))
           //
@@ -376,9 +381,10 @@ final class ConsumeAction(val topicPartition: TopicPartition,
 
   override def describe(output: PrintStream): Unit = {
     output.println(s"consume-action:")
-    output.println(s"  fetch-offset: $fetchOffset")
-    output.println(s"  expected-record-count: $expectedTotalCount")
-    output.println(s"  expected-record-from-tiered-storage $expectedFromSecondTierCount")
+    output.println(s"  topic-partition = $topicPartition")
+    output.println(s"  fetch-offset = $fetchOffset")
+    output.println(s"  expected-record-count = $expectedTotalCount")
+    output.println(s"  expected-record-from-tiered-storage = $expectedFromSecondTierCount")
   }
 }
 

--- a/core/src/test/scala/kafka/tiered/storage/TieredStorageTests.scala
+++ b/core/src/test/scala/kafka/tiered/storage/TieredStorageTests.scala
@@ -200,13 +200,13 @@ object TieredStorageTests {
 
         .stop(follower)
         .produce(topicA, p0, ("k2", "v2"), ("k3", "v3"))
-        .expectSegmentToBeOffloaded(leader, topicA, p0, baseOffset = 0, segmentSize = 1)
         .expectSegmentToBeOffloaded(leader, topicA, p0, baseOffset = 1, segmentSize = 1)
 
         .stop(leader)
         .start(follower)
         .expectLeader(topicA, p0, follower)
         .produce(topicA, p0, ("k4", "v4"), ("k5", "v5"))
+        .expectSegmentToBeOffloaded(follower, topicA, p0, baseOffset = 0, segmentSize = 1)
         .expectSegmentToBeOffloaded(follower, topicA, p0, baseOffset = 1, segmentSize = 1)
     }
   }

--- a/core/src/test/scala/kafka/tiered/storage/TieredStorageTests.scala
+++ b/core/src/test/scala/kafka/tiered/storage/TieredStorageTests.scala
@@ -186,6 +186,32 @@ object TieredStorageTests {
     }
   }
 
+  final class UncleanLeaderElectionAndTieredStorageTest extends TieredStorageTestHarness {
+    private val (leader, follower, _, topicA, p0) = (0, 1, 2, "topicA", 0)
+
+    override protected def brokerCount: Int = 3
+
+    override protected def writeTestSpecifications(builder: TieredStorageTestBuilder): Unit = {
+      val assignment = Map(p0 -> Seq(leader, follower))
+
+      builder
+        .createTopic(topicA, partitionsCount = 1, replicationFactor = 2, segmentSize = 1, assignment)
+        .produce(topicA, p0, ("k1", "v1"))
+
+        .stop(follower)
+        .produce(topicA, p0, ("k2", "v2"), ("k3", "v3"))
+        .expectSegmentToBeOffloaded(leader, topicA, p0, baseOffset = 0, segmentSize = 1)
+        .expectSegmentToBeOffloaded(leader, topicA, p0, baseOffset = 1, segmentSize = 1)
+
+        /*.stop(leader)
+        .start(follower)
+        .expectLeader(topicA, p0, follower)
+        .produce(topicA, p0, ("k4", "v4"), ("k5", "v5"))
+
+        .expectSegmentToBeOffloaded(leader, topicA, p0, baseOffset = 1, segmentSize = 1)*/
+    }
+  }
+
   //
   // TODO: fetch from follower not implemented.
   //

--- a/core/src/test/scala/kafka/tiered/storage/TieredStorageTests.scala
+++ b/core/src/test/scala/kafka/tiered/storage/TieredStorageTests.scala
@@ -203,12 +203,11 @@ object TieredStorageTests {
         .expectSegmentToBeOffloaded(leader, topicA, p0, baseOffset = 0, segmentSize = 1)
         .expectSegmentToBeOffloaded(leader, topicA, p0, baseOffset = 1, segmentSize = 1)
 
-        /*.stop(leader)
+        .stop(leader)
         .start(follower)
         .expectLeader(topicA, p0, follower)
         .produce(topicA, p0, ("k4", "v4"), ("k5", "v5"))
-
-        .expectSegmentToBeOffloaded(leader, topicA, p0, baseOffset = 1, segmentSize = 1)*/
+        .expectSegmentToBeOffloaded(follower, topicA, p0, baseOffset = 1, segmentSize = 1)
     }
   }
 

--- a/core/src/test/scala/unit/kafka/utils/BrokerLocalStorage.scala
+++ b/core/src/test/scala/unit/kafka/utils/BrokerLocalStorage.scala
@@ -24,7 +24,10 @@ import kafka.log.Log
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.utils.Time
 
-final class BrokerLocalStorage(private val storageDirname: String, private val storageWaitTimeoutSec: Int) {
+final class BrokerLocalStorage(val brokerId: Int,
+                               private val storageDirname: String,
+                               private val storageWaitTimeoutSec: Int) {
+
   private val brokerStorageDirectory = new File(storageDirname)
   private val storagePollPeriodSec = 1
   private val time = Time.SYSTEM
@@ -47,9 +50,9 @@ final class BrokerLocalStorage(private val storageDirname: String, private val s
 
     if (earliestOffset._1 < offset) {
       val sep = System.lineSeparator()
-      val message = s"The base offset of the first log segment of $topicPartition in the log directory is " +
-        s"${earliestOffset._1} which is smaller than the expected offset $offset. The directory of $topicPartition " +
-        s"is made of the following files: $sep${earliestOffset._2.mkString(sep)}"
+      val message = s"[BrokerId=$brokerId] The base offset of the first log segment of $topicPartition in the log" +
+        s"directory is ${earliestOffset._1} which is smaller than the expected offset $offset. The directory of" +
+        s"$topicPartition is made of the following files: $sep${earliestOffset._2.mkString(sep)}"
 
       throw new AssertionError(message)
     }

--- a/core/src/test/scala/unit/kafka/utils/BrokerLocalStorage.scala
+++ b/core/src/test/scala/unit/kafka/utils/BrokerLocalStorage.scala
@@ -81,7 +81,8 @@ final class BrokerLocalStorage(val brokerId: Int,
       .map(_.getName)
       .find(_ == topicPartition.toString)
       .getOrElse {
-        throw new IllegalArgumentException(s"Directory for the topic-partition $topicPartition was not found")
+        throw new IllegalArgumentException(
+          s"[BrokerId=$brokerId] Directory for the topic-partition $topicPartition was not found")
       }
 
     new File(brokerStorageDirectory, topicPartitionDir)

--- a/core/src/test/scala/unit/kafka/utils/RecordsKeyValueMatcher.scala
+++ b/core/src/test/scala/unit/kafka/utils/RecordsKeyValueMatcher.scala
@@ -56,7 +56,7 @@ final class RecordsKeyValueMatcher[R1, R2, K, V](private val expectedRecords: It
   extends TypeSafeDiagnosingMatcher[Iterable[R2]] {
 
   override def describeTo(description: Description): Unit = {
-    description.appendText(s"Marcher for records of $topicPartition")
+    description.appendText(s"Records of $topicPartition: $expectedRecords")
   }
 
   override def matchesSafely(actualRecord: Iterable[R2], mismatchDescription: Description): Boolean = {
@@ -95,7 +95,7 @@ final class RecordsKeyValueMatcher[R1, R2, K, V](private val expectedRecords: It
           .appendValue(deserializer.deserialize(topicPartition.topic(), Utils.toNullableArray(lhs)))
           .appendText("; Actual: ")
           .appendValue(deserializer.deserialize(topicPartition.topic(), Utils.toNullableArray(rhs)))
-          .appendText(";")
+          .appendText("; ")
 
         false
       } else true


### PR DESCRIPTION
- Support producing to a log segment already contained records in `produce-action`.
- Generate basic test reports with one description per test action.

e.g.

```
[SUCCESS] (1) create-topic: Topic[name=topicA partition-count=1 replication-factor=1 segment-size=1 assignment=None]

[SUCCESS] (2) produce-records:
  topicA-0
    ProducerRecord(topic=topicA, partition=0, headers=RecordHeaders(headers = [], isReadOnly = true), key=k1, value=v1, timestamp=null)
    ProducerRecord(topic=topicA, partition=0, headers=RecordHeaders(headers = [], isReadOnly = true), key=k2, value=v2, timestamp=null)
    ProducerRecord(topic=topicA, partition=0, headers=RecordHeaders(headers = [], isReadOnly = true), key=k3, value=v3, timestamp=null)
  topicA-0
    Segment[topicA-0 offloaded-by-broker-id=0 base-offset=0 record-count=1]
    Segment[topicA-0 offloaded-by-broker-id=0 base-offset=1 record-count=1]

[SUCCESS] (3) create-topic: Topic[name=topicB partition-count=1 replication-factor=1 segment-size=2 assignment=None]

[SUCCESS] (4) produce-records:
  topicB-0
    ProducerRecord(topic=topicB, partition=0, headers=RecordHeaders(headers = [], isReadOnly = true), key=k1, value=v1, timestamp=null)
    ProducerRecord(topic=topicB, partition=0, headers=RecordHeaders(headers = [], isReadOnly = true), key=k2, value=v2, timestamp=null)
    ProducerRecord(topic=topicB, partition=0, headers=RecordHeaders(headers = [], isReadOnly = true), key=k3, value=v3, timestamp=null)
  topicB-0
    Segment[topicB-0 offloaded-by-broker-id=0 base-offset=0 record-count=2]

[SUCCESS] (5) bounce-broker: 0

[SUCCESS] (6) consume-action:
  topic-partition = topicA-0
  fetch-offset = 1
  expected-record-count = 2
  expected-record-from-tiered-storage = 1

[SUCCESS] (7) consume-action:
  topic-partition = topicB-0
  fetch-offset = 1
  expected-record-count = 2
  expected-record-from-tiered-storage = 1

Content of local tiered storage:

    File                                                | Base offset |  End offset |  Base record |   End record
-----------------------------------------------------------------------------------------------------------------
topicB-0                                                |             |             |              |             
    a854411f-93b4-471a-a41d-9fd62f1be81d-segment        |           0 |           1 |     (k1, v1) |     (k2, v2)
    a854411f-93b4-471a-a41d-9fd62f1be81d-offset_index   |             |             |              |             
    a854411f-93b4-471a-a41d-9fd62f1be81d-time_index     |             |             |              |             
                                                        |             |             |              |             
topicA-0                                                |             |             |              |             
    3efd76d5-a52b-45e8-83fa-6e5f1bc3facf-segment        |           0 |           0 |     (k1, v1) |     (k1, v1)
    3efd76d5-a52b-45e8-83fa-6e5f1bc3facf-offset_index   |             |             |              |             
    3efd76d5-a52b-45e8-83fa-6e5f1bc3facf-time_index     |             |             |              |             
                                                        |             |             |              |             
    215b4bb1-f354-47bc-8e85-64487e66423c-segment        |           1 |           1 |     (k2, v2) |     (k2, v2)
    215b4bb1-f354-47bc-8e85-64487e66423c-offset_index   |             |             |              |             
    215b4bb1-f354-47bc-8e85-64487e66423c-time_index     |             |             |              |             
                                                        |             |             |              |             


```