### PR TITLE
Add prefix to S3RemoteStorageManagerConfig

### DIFF
--- a/remote-storage-managers/s3/src/main/java/org/apache/kafka/rsm/s3/S3RemoteStorageManagerConfig.java
+++ b/remote-storage-managers/s3/src/main/java/org/apache/kafka/rsm/s3/S3RemoteStorageManagerConfig.java
@@ -26,18 +26,20 @@ import org.apache.kafka.common.config.ConfigException;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.regions.Regions;
 
+import static kafka.log.remote.RemoteLogManager.REMOTE_STORAGE_MANAGER_CONFIG_PREFIX;
+
 /**
  * A configuration for {@link S3RemoteStorageManager}.
  */
 public class S3RemoteStorageManagerConfig extends AbstractConfig {
-    public static final String S3_BUCKET_NAME_CONFIG = "s3.bucket.name";
+    public static final String S3_BUCKET_NAME_CONFIG = REMOTE_STORAGE_MANAGER_CONFIG_PREFIX() + "s3.bucket.name";
     private static final String S3_BUCKET_NAME_DOC = "The S3 Bucket.";
 
-    public static final String S3_REGION_CONFIG = "s3.region";
+    public static final String S3_REGION_CONFIG = REMOTE_STORAGE_MANAGER_CONFIG_PREFIX() + "s3.region";
     private static final String S3_REGION_DEFAULT = Regions.DEFAULT_REGION.getName();
     private static final String S3_REGION_DOC = "The AWS region.";
 
-    public static final String S3_CREDENTIALS_PROVIDER_CLASS_CONFIG = "s3.credentials.provider.class";
+    public static final String S3_CREDENTIALS_PROVIDER_CLASS_CONFIG = REMOTE_STORAGE_MANAGER_CONFIG_PREFIX() + "s3.credentials.provider.class";
     private static final Class<? extends AWSCredentialsProvider> S3_CREDENTIALS_PROVIDER_CLASS_DEFAULT = null;
     private static final String S3_CREDENTIALS_PROVIDER_CLASS_DOC = "The credentials provider to use for " +
         "authentication to AWS. If not set, AWS SDK uses the default " +


### PR DESCRIPTION
The configurations were missing `remote.log.storage.` prefix.