### PR TITLE
Fix the truncation of leader epoch checkpoint when uploading the segment

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/log/remote/storage/LogSegmentData.java
+++ b/clients/src/main/java/org/apache/kafka/common/log/remote/storage/LogSegmentData.java
@@ -25,16 +25,16 @@ public class LogSegmentData {
     private final File timeIndex;
     private final File txnIndex;
     private final File producerIdSnapshotIndex;
-    private final File leaderEpochCache;
+    private final File leaderEpochCheckpoint;
 
     public LogSegmentData(File logSegment, File offsetIndex, File timeIndex, File txnIndex, File producerIdSnapshotIndex,
-                          File leaderEpochCache) {
+                          File leaderEpochCheckpoint) {
         this.logSegment = logSegment;
         this.offsetIndex = offsetIndex;
         this.timeIndex = timeIndex;
         this.txnIndex = txnIndex;
         this.producerIdSnapshotIndex = producerIdSnapshotIndex;
-        this.leaderEpochCache = leaderEpochCache;
+        this.leaderEpochCheckpoint = leaderEpochCheckpoint;
     }
 
     public File logSegment() {
@@ -57,7 +57,7 @@ public class LogSegmentData {
         return producerIdSnapshotIndex;
     }
 
-    public File leaderEpochCache() {
-        return leaderEpochCache;
+    public File leaderEpochCheckpoint() {
+        return leaderEpochCheckpoint;
     }
 }

--- a/clients/src/test/java/org/apache/kafka/common/log/remote/storage/LocalTieredStorageEvent.java
+++ b/clients/src/test/java/org/apache/kafka/common/log/remote/storage/LocalTieredStorageEvent.java
@@ -40,6 +40,9 @@ public final class LocalTieredStorageEvent implements Comparable<LocalTieredStor
         FETCH_SEGMENT,
         FETCH_OFFSET_INDEX,
         FETCH_TIME_INDEX,
+        FETCH_TRANSACTION_INDEX,
+        FETCH_LEADER_EPOCH_CHECKPOINT,
+        FETCH_PRODUCER_SNAPSHOT,
         DELETE_SEGMENT
     }
 

--- a/clients/src/test/java/org/apache/kafka/common/log/remote/storage/RemoteTopicPartitionDirectory.java
+++ b/clients/src/test/java/org/apache/kafka/common/log/remote/storage/RemoteTopicPartitionDirectory.java
@@ -119,8 +119,8 @@ public final class RemoteTopicPartitionDirectory {
     public static RemoteTopicPartitionDirectory openExistingTopicPartitionDirectory(final String dirname,
                                                                                     final File storageDirectory) {
 
-        final char topicParitionSeparator = '-';
-        final int separatorIndex = dirname.lastIndexOf(topicParitionSeparator);
+        final char topicPartitionSeparator = '-';
+        final int separatorIndex = dirname.lastIndexOf(topicPartitionSeparator);
 
         if (separatorIndex == -1) {
             throw new IllegalArgumentException(format(
@@ -141,8 +141,8 @@ public final class RemoteTopicPartitionDirectory {
         final RemoteTopicPartitionDirectory directory =
                 openTopicPartitionDirectory(new TopicPartition(topic, partition), storageDirectory);
 
-        if (!directory.existed) {
-            throw new IllegalArgumentException(format("Topic-partitition directory %s not found", dirname));
+        if (!directory.didExist()) {
+            throw new IllegalArgumentException(format("Topic-partition directory %s not found", dirname));
         }
 
         return directory;

--- a/core/src/main/scala/kafka/log/remote/ClassLoaderAwareRemoteStorageManager.scala
+++ b/core/src/main/scala/kafka/log/remote/ClassLoaderAwareRemoteStorageManager.scala
@@ -37,59 +37,43 @@ class ClassLoaderAwareRemoteStorageManager(val rsm: RemoteStorageManager,
     }
   }
 
-  //FIXME: Remove
+  // FIXME: Remove
   def delegate(): RemoteStorageManager = {
     rsm
   }
 
-  override def close(): Unit = {
-    withClassLoader {
-      rsm.close()
-    }
+  override def close(): Unit = withClassLoader {
+    rsm.close()
   }
 
-  override def configure(configs: util.Map[String, _]): Unit = {
-    withClassLoader {
-      rsm.configure(configs)
-    }
+  override def configure(configs: util.Map[String, _]): Unit = withClassLoader {
+    rsm.configure(configs)
   }
 
-  override def copyLogSegment(remoteLogSegmentMetadata: RemoteLogSegmentMetadata, logSegmentData: LogSegmentData): Unit = {
-    withClassLoader {
-      rsm.copyLogSegment(remoteLogSegmentMetadata, logSegmentData)
-    }
+  override def copyLogSegment(remoteLogSegmentMetadata: RemoteLogSegmentMetadata,
+                              logSegmentData: LogSegmentData): Unit = withClassLoader {
+    rsm.copyLogSegment(remoteLogSegmentMetadata, logSegmentData)
   }
 
   override def fetchLogSegmentData(remoteLogSegmentMetadata: RemoteLogSegmentMetadata,
                                    startPosition: lang.Long,
-                                   endPosition: lang.Long): InputStream = {
-    withClassLoader {
-      rsm.fetchLogSegmentData(remoteLogSegmentMetadata, startPosition, endPosition)
-    }
+                                   endPosition: lang.Long): InputStream = withClassLoader {
+    rsm.fetchLogSegmentData(remoteLogSegmentMetadata, startPosition, endPosition)
   }
 
-  override def fetchOffsetIndex(remoteLogSegmentMetadata: RemoteLogSegmentMetadata): InputStream = {
-    withClassLoader {
-      rsm.fetchOffsetIndex(remoteLogSegmentMetadata)
-    }
-
+  override def fetchOffsetIndex(remoteLogSegmentMetadata: RemoteLogSegmentMetadata): InputStream = withClassLoader {
+    rsm.fetchOffsetIndex(remoteLogSegmentMetadata)
   }
 
-  override def fetchTimestampIndex(remoteLogSegmentMetadata: RemoteLogSegmentMetadata): InputStream = {
-    withClassLoader {
-      rsm.fetchTimestampIndex(remoteLogSegmentMetadata)
-    }
+  override def fetchTimestampIndex(remoteLogSegmentMetadata: RemoteLogSegmentMetadata): InputStream = withClassLoader {
+    rsm.fetchTimestampIndex(remoteLogSegmentMetadata)
   }
 
-  override def deleteLogSegment(remoteLogSegmentMetadata: RemoteLogSegmentMetadata): Unit = {
-    withClassLoader {
-      rsm.deleteLogSegment(remoteLogSegmentMetadata)
-    }
+  override def deleteLogSegment(remoteLogSegmentMetadata: RemoteLogSegmentMetadata): Unit = withClassLoader {
+    rsm.deleteLogSegment(remoteLogSegmentMetadata)
   }
 
-  override def fetchTransactionIndex(remoteLogSegmentMetadata: RemoteLogSegmentMetadata): InputStream = {
-    withClassLoader {
-      rsm.fetchTransactionIndex(remoteLogSegmentMetadata)
-    }
+  override def fetchTransactionIndex(remoteLogSegmentMetadata: RemoteLogSegmentMetadata): InputStream = withClassLoader {
+    rsm.fetchTransactionIndex(remoteLogSegmentMetadata)
   }
 }

--- a/core/src/main/scala/kafka/log/remote/RemoteIndexCache.scala
+++ b/core/src/main/scala/kafka/log/remote/RemoteIndexCache.scala
@@ -21,7 +21,6 @@ import java.nio.file.{Files, Path}
 import java.util
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.atomic.AtomicBoolean
-import java.util.function.{Consumer, Function}
 
 import kafka.log.{CleanableIndex, Log, OffsetIndex, OffsetPosition, TimeIndex, TransactionIndex, TxnIndexSearchResult}
 import kafka.utils.{CoreUtils, Logging}
@@ -45,11 +44,11 @@ class Entry(val offsetIndex: OffsetIndex, val timeIndex: TimeIndex, val txnIndex
     else offsetIndex.lookup(targetOffset)
   }
 
-  def lookupTimestamp(timestamp: Long, startingOffset: Long): Long = {
+  def lookupTimestamp(timestamp: Long, startingOffset: Long): OffsetPosition = {
     if (closed.get()) throw new IllegalStateException("This entry is already closed")
 
     val timestampOffset = timeIndex.lookup(timestamp)
-    offsetIndex.lookup(math.max(startingOffset, timestampOffset.offset)).position
+    offsetIndex.lookup(math.max(startingOffset, timestampOffset.offset))
   }
 
   def close(): Unit = {
@@ -69,7 +68,7 @@ class Entry(val offsetIndex: OffsetIndex, val timeIndex: TimeIndex, val txnIndex
 class RemoteIndexCache(maxSize: Int = 1024, remoteStorageManager: RemoteStorageManager, logDir: String) extends Logging {
 
   val cacheDir = new File(logDir, "remote-log-index-cache")
-  @volatile var closed = false;
+  @volatile var closed = false
 
   val expiredIndexes = new LinkedBlockingQueue[Entry]()
   val lock = new Object()
@@ -89,15 +88,14 @@ class RemoteIndexCache(maxSize: Int = 1024, remoteStorageManager: RemoteStorageM
     }
   }
 
-  private def init() = {
-    if (cacheDir.mkdir()) info(s"Created $cacheDir successfully")
+  private def init(): Unit = {
+    if (cacheDir.mkdir())
+      info(s"Created $cacheDir successfully")
 
     // delete any .deleted files remained from the earlier run of the broker.
-    Files.list(cacheDir.toPath).forEach(new Consumer[Path] {
-      override def accept(path: Path): Unit = {
-        if (path.endsWith(Log.DeletedFileSuffix) || path.endsWith(Log.DeletedFileSuffix)) {
-          Files.deleteIfExists(path)
-        }
+    Files.list(cacheDir.toPath).forEach((path: Path) => {
+      if (path.endsWith(Log.DeletedFileSuffix)) {
+        Files.deleteIfExists(path)
       }
     })
 
@@ -107,25 +105,24 @@ class RemoteIndexCache(maxSize: Int = 1024, remoteStorageManager: RemoteStorageM
   init()
 
   // Start cleaner thread that will clean the expired entries
-  val cleanerThread = KafkaThread.daemon("remote-log-index-cleaner", new Runnable {
-    override def run(): Unit = {
-      while (!closed) {
-        try {
-          val entry = expiredIndexes.take()
-          info(s"Cleaning up index entry $entry")
-          entry.cleanup()
-        } catch {
-          case ex: Exception => error("Error occurred while fetching/cleaning up expired entry", ex)
-        }
+  val cleanerThread: KafkaThread = KafkaThread.daemon("remote-log-index-cleaner", () => {
+    while (!closed) {
+      try {
+        val entry = expiredIndexes.take()
+        info(s"Cleaning up index entry $entry")
+        entry.cleanup()
+      } catch {
+        case ex: Exception => error("Error occurred while fetching/cleaning up expired entry", ex)
       }
     }
   })
   cleanerThread.start()
 
   def getIndexEntry(remoteLogSegmentMetadata: RemoteLogSegmentMetadata): Entry = {
-    def loadIndexFile[T <: CleanableIndex](fileName: String, suffix: String,
-                                                fetchRemoteIndex: RemoteLogSegmentMetadata => InputStream,
-                                                createIndex: File => T): T = {
+    def loadIndexFile[T <: CleanableIndex](fileName: String,
+                                           suffix: String,
+                                           fetchRemoteIndex: RemoteLogSegmentMetadata => InputStream,
+                                           readIndex: File => T): T = {
       val indexFile = new File(cacheDir, fileName + suffix)
 
       def fetchAndCreateIndex(): T = {
@@ -133,23 +130,23 @@ class RemoteIndexCache(maxSize: Int = 1024, remoteStorageManager: RemoteStorageM
         val tmpIndexFile = new File(cacheDir, fileName + suffix + RemoteIndexCache.TmpFileSuffix)
 
         // Below FileChannel#transferFrom call may be efficient as it goes through a fast path of transferring directly
-        //from the source channel into the filesystem cache. But if it goes through non-fast path then it expects the
-        //inputStream to always have available bytes. This is an unnecessary restriction on RemoteStorageManager to
-        //always return InputStream to have available bytes till the end.
+        // from the source channel into the filesystem cache. But if it goes through non-fast path then it expects the
+        // inputStream to always have available bytes. This is an unnecessary restriction on RemoteStorageManager to
+        // always return InputStream to have available bytes till the end.
         // FileChannel.open(tmpIndexFile.toPath, StandardOpenOption.CREATE, StandardOpenOption.WRITE)
         // .transferFrom(sourceChannel, 0, Int.MaxValue)
         Files.copy(inputStream, tmpIndexFile.toPath)
 
         Utils.atomicMoveWithFallback(tmpIndexFile.toPath, indexFile.toPath)
-        createIndex(indexFile)
+        readIndex(indexFile)
       }
 
       if (indexFile.exists()) {
         try {
-          createIndex(indexFile)
+          readIndex(indexFile)
         } catch {
           case ex: CorruptRecordException =>
-            info("Error occurred while loading the stored index ", ex)
+            info("Error occurred while loading the stored index", ex)
             fetchAndCreateIndex()
         }
       } else {
@@ -158,36 +155,35 @@ class RemoteIndexCache(maxSize: Int = 1024, remoteStorageManager: RemoteStorageM
     }
 
     lock synchronized {
-      entries.computeIfAbsent(remoteLogSegmentMetadata.remoteLogSegmentId(), new Function[RemoteLogSegmentId, Entry] {
-        override def apply(key: RemoteLogSegmentId): Entry = {
-          val fileSuffix = remoteLogSegmentMetadata.remoteLogSegmentId().id().toString
-          val startOffset = remoteLogSegmentMetadata.startOffset()
+      entries.computeIfAbsent(remoteLogSegmentMetadata.remoteLogSegmentId(), (key: RemoteLogSegmentId) => {
+        val fileName = key.id().toString
+        val startOffset = remoteLogSegmentMetadata.startOffset()
 
-          val offsetIndex: OffsetIndex = loadIndexFile(fileSuffix, RemoteIndexCache.OffsetIndexFileSuffix,
-            rlsMetadata => remoteStorageManager.fetchOffsetIndex(rlsMetadata), file => {
-              val index = new OffsetIndex(file, startOffset, Int.MaxValue, writable = false)
-              index.sanityCheck()
-              index
-            })
+        val offsetIndex: OffsetIndex = loadIndexFile(fileName, RemoteIndexCache.OffsetIndexFileSuffix,
+          rlsMetadata => remoteStorageManager.fetchOffsetIndex(rlsMetadata),
+          file => {
+            val index = new OffsetIndex(file, startOffset, Int.MaxValue, writable = false)
+            index.sanityCheck()
+            index
+          })
 
-          val timeIndex = loadIndexFile(fileSuffix, RemoteIndexCache.TimeIndexFileSuffix,
-            rlsMetadata => remoteStorageManager.fetchTimestampIndex(rlsMetadata),
-            file => {
-              val index = new TimeIndex(file, startOffset, Int.MaxValue, writable = false)
-              index.sanityCheck()
-              index
-            })
+        val timeIndex: TimeIndex = loadIndexFile(fileName, RemoteIndexCache.TimeIndexFileSuffix,
+          rlsMetadata => remoteStorageManager.fetchTimestampIndex(rlsMetadata),
+          file => {
+            val index = new TimeIndex(file, startOffset, Int.MaxValue, writable = false)
+            index.sanityCheck()
+            index
+          })
 
-          val txnIndex:TransactionIndex = loadIndexFile(fileSuffix, RemoteIndexCache.TxnIndexFileSuffix,
-            rlsMetadata => remoteStorageManager.fetchTransactionIndex(rlsMetadata),
-            file => {
-              val index = new TransactionIndex(startOffset, file)
-              index.sanityCheck()
-              index
-            })
+        val txnIndex: TransactionIndex = loadIndexFile(fileName, RemoteIndexCache.TxnIndexFileSuffix,
+          rlsMetadata => remoteStorageManager.fetchTransactionIndex(rlsMetadata),
+          file => {
+            val index = new TransactionIndex(startOffset, file)
+            index.sanityCheck()
+            index
+          })
 
-          new Entry(offsetIndex, timeIndex, txnIndex)
-        }
+        new Entry(offsetIndex, timeIndex, txnIndex)
       })
     }
   }
@@ -197,10 +193,11 @@ class RemoteIndexCache(maxSize: Int = 1024, remoteStorageManager: RemoteStorageM
   }
 
   def lookupTimestamp(remoteLogSegmentMetadata: RemoteLogSegmentMetadata, timestamp: Long, startingOffset: Long): Long = {
-    getIndexEntry(remoteLogSegmentMetadata).lookupTimestamp(timestamp, startingOffset)
+    getIndexEntry(remoteLogSegmentMetadata).lookupTimestamp(timestamp, startingOffset).position
   }
 
-  def collectAbortedTransaction(remoteLogSegmentMetadata: RemoteLogSegmentMetadata, startOffset: Long,
+  def collectAbortedTransaction(remoteLogSegmentMetadata: RemoteLogSegmentMetadata,
+                                startOffset: Long,
                                 fetchSize: Int): TxnIndexSearchResult = {
     val entry = getIndexEntry(remoteLogSegmentMetadata)
     val maxOffset = entry.offsetIndex.fetchUpperBoundOffset(entry.offsetIndex.lookup(startOffset), fetchSize)

--- a/core/src/main/scala/kafka/log/remote/RemoteLogReader.scala
+++ b/core/src/main/scala/kafka/log/remote/RemoteLogReader.scala
@@ -21,8 +21,10 @@ import kafka.server.{BrokerTopicStats, FetchDataInfo, RemoteStorageFetchInfo}
 import kafka.utils.Logging
 import org.apache.kafka.common.utils.Time
 
-class RemoteLogReader(fetchInfo: RemoteStorageFetchInfo, rlm: RemoteLogManager, brokerTopicStats: BrokerTopicStats, callback: (RemoteLogReadResult) => Unit)
-  extends RemoteStorageTask[Unit] with Logging {
+class RemoteLogReader(fetchInfo: RemoteStorageFetchInfo,
+                      rlm: RemoteLogManager,
+                      brokerTopicStats: BrokerTopicStats,
+                      callback: RemoteLogReadResult => Unit) extends RemoteStorageTask[Unit] with Logging {
   brokerTopicStats.topicStats(fetchInfo.topicPartition.topic()).remoteReadRequestRate.mark()
 
   override def execute(): Unit = {

--- a/core/src/main/scala/kafka/server/FetchDataInfo.scala
+++ b/core/src/main/scala/kafka/server/FetchDataInfo.scala
@@ -33,5 +33,5 @@ case class FetchDataInfo(fetchOffsetMetadata: LogOffsetMetadata,
                          abortedTransactions: Option[List[AbortedTransaction]] = None,
                          delayedRemoteStorageFetch: Option[RemoteStorageFetchInfo] = None)
 
-case class RemoteStorageFetchInfo(fetchMaxByes: Int, minOneMessage: Boolean, topicPartition: TopicPartition,
+case class RemoteStorageFetchInfo(fetchMaxBytes: Int, minOneMessage: Boolean, topicPartition: TopicPartition,
                                   fetchInfo: PartitionData, fetchIsolation: FetchIsolation)


### PR DESCRIPTION
- Add support to copy the tx, leader_epoch checkpoint & snapshot files in the LocalTieredStorage.
- Fixed the truncation of leader epoch checkpoint after uploading the segment.
- Added test to verify the upload of index, epoch, and snapshot files.
- Minor code cleanups.
