### PR TITLE
Added message formatter to view the contents of remote metadata log.

### DIFF
--- a/core/src/main/scala/kafka/log/remote/RemoteMetadataLog.scala
+++ b/core/src/main/scala/kafka/log/remote/RemoteMetadataLog.scala
@@ -1,0 +1,71 @@
+package kafka.log.remote
+
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.common.MessageFormatter
+import org.apache.kafka.common.log.remote.metadata.storage.RLSMSerDe
+import org.apache.kafka.common.log.remote.storage.RemoteLogSegmentMetadata
+import org.apache.kafka.common.record.Record
+import org.apache.kafka.common.serialization.Serdes.StringSerde
+import org.apache.kafka.common.utils.Utils
+
+import java.io.PrintStream
+import java.nio.ByteBuffer
+import java.nio.ByteBuffer.wrap
+
+object RemoteMetadataLog {
+
+  val keySerde = new StringSerde
+  val valSerde = new RLSMSerDe
+
+  private[remote] def keyToBytes(data: String): Array[Byte] = {
+    keySerde.serializer().serialize(null, data)
+  }
+
+  private def readMetadataRecordKey(data: ByteBuffer): String = {
+    keySerde.deserializer().deserialize(null, Utils.readBytes(data))
+  }
+
+  private[remote] def valueToBytes(data: RemoteLogSegmentMetadata): Array[Byte] = {
+    valSerde.serializer().serialize(null, data)
+  }
+
+  private def readMetadataRecordValue(buffer: ByteBuffer): Option[RemoteLogSegmentMetadata] = {
+    if (buffer == null) {
+      None
+    } else {
+      Some(valSerde.deserializer().deserialize(null, Utils.readBytes(buffer)))
+    }
+  }
+
+  class RMLMessageFormatter extends MessageFormatter {
+    /**
+     * Parses and formats a record for display
+     *
+     * @param consumerRecord the record to format
+     * @param output         the print stream used to output the record
+     */
+    override def writeTo(consumerRecord: ConsumerRecord[Array[Byte], Array[Byte]], output: PrintStream): Unit = {
+      Option(consumerRecord.key()).map(key => readMetadataRecordKey(wrap(key))).foreach { recordKey =>
+        val value = readMetadataRecordValue(wrap(consumerRecord.value()))
+        var result = "partition: " + recordKey + ", message-offset: " + consumerRecord.offset()
+        value.foreach(x => {
+          result += ", type: " + x.getClass.getSimpleName
+          result += ", event-value: " + x.toString
+        })
+        output.println(result)
+      }
+    }
+  }
+
+  /**
+   * Exposed for printing records using [[kafka.tools.DumpLogSegments]]
+   */
+  def formatRecordKeyAndValue(record: Record): (Option[String], Option[String]) = {
+    val key = readMetadataRecordKey(record.key())
+    val payload = readMetadataRecordValue(record.value()) match {
+      case None => "<EMPTY>"
+      case Some(value) => value.toString
+    }
+    (Some(key), Some(payload))
+  }
+}

--- a/core/src/test/scala/kafka/log/remote/RemoteMetadataLogTest.scala
+++ b/core/src/test/scala/kafka/log/remote/RemoteMetadataLogTest.scala
@@ -1,0 +1,48 @@
+package kafka.log.remote
+
+import kafka.utils.{MockTime, TestUtils}
+import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.log.remote.storage.{RemoteLogSegmentId, RemoteLogSegmentMetadata}
+import org.apache.kafka.common.record.SimpleRecord
+import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
+import org.junit.jupiter.api.Test
+
+import java.util.{Collections, UUID}
+import scala.jdk.CollectionConverters._
+
+class RemoteMetadataLogTest {
+
+  val time = new MockTime()
+
+  @Test
+  def testFormatRecordKeyValue(): Unit = {
+    val topic = "topic"
+    val topicPartition = new TopicPartition(topic, 0)
+    val timestamp = time.hiResClockMs()
+
+    val metadata = new RemoteLogSegmentMetadata(new RemoteLogSegmentId(topicPartition, UUID.randomUUID()), 5,
+      10, timestamp, 2, timestamp, 100,
+      RemoteLogSegmentMetadata.State.COPY_STARTED, Collections.emptyMap())
+
+    val keyBytes = RemoteMetadataLog.keyToBytes(topicPartition.toString)
+    val valueBytes = RemoteMetadataLog.valueToBytes(metadata)
+    val remoteLogMetadataRecord = TestUtils.records(Seq(
+      new SimpleRecord(keyBytes, valueBytes)
+    )).records.asScala.head
+
+    val actual = RemoteMetadataLog.formatRecordKeyAndValue(remoteLogMetadataRecord)
+    assertEquals(topicPartition.toString, actual._1.get)
+    assertEquals(metadata.toString, actual._2.get)
+  }
+
+  @Test
+  def testFormatEmptyRecordKeyValue(): Unit = {
+    val emptyBytes = Array[Byte]()
+    val remoteLogMetadataRecord = TestUtils.records(Seq(
+      new SimpleRecord(emptyBytes, null)
+    )).records.asScala.head
+    val actual = RemoteMetadataLog.formatRecordKeyAndValue(remoteLogMetadataRecord)
+    assertTrue(actual._1.get.isEmpty)
+    assertEquals("<EMPTY>", actual._2.get)
+  }
+}


### PR DESCRIPTION
- The remote log metadata content can be viewed using kafka-console-consumer (or) kafka-dump-log script.
- sh kafka-dump-log.sh --files <segment_file> --remote-metadata-log-decoder -print-data-log
- sh kafka-console-consumer.sh --bootstrap-server \<listeners\> --topic __remote_log_segment_metadata --from-beginning --formatter kafka.log.remote.RemoteMetadataLog\\$RMLMessageFormatter