### PR TITLE
Follower fetch protocol v1 implementation

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/log/remote/metadata/storage/ConsumerTask.java
+++ b/clients/src/main/java/org/apache/kafka/common/log/remote/metadata/storage/ConsumerTask.java
@@ -158,7 +158,7 @@ class ConsumerTask implements Runnable, Closeable {
                 if (!targetEndOffsets.isEmpty()) {
                     for (Map.Entry<Integer, Long> entry : targetEndOffsets.entrySet()) {
                         final Long offset = committedOffsets.getOrDefault(entry.getKey(), 0L);
-                        if (offset >= entry.getValue()) {
+                        if (offset > entry.getValue()) {
                             targetEndOffsets.remove(entry.getKey());
                         }
                     }

--- a/clients/src/main/java/org/apache/kafka/common/log/remote/metadata/storage/RLMMWithTopicStorage.java
+++ b/clients/src/main/java/org/apache/kafka/common/log/remote/metadata/storage/RLMMWithTopicStorage.java
@@ -91,6 +91,7 @@ public class RLMMWithTopicStorage implements RemoteLogMetadataManager, RemoteLog
     protected int noOfMetadataTopicPartitions;
     private ConcurrentSkipListMap<RemoteLogSegmentId, RemoteLogSegmentMetadata> idWithSegmentMetadata =
             new ConcurrentSkipListMap<>();
+    // map of topic-partition to (log-segment-base-offset, remote-segment-id)
     private Map<TopicPartition, NavigableMap<Long, RemoteLogSegmentId>> partitionsWithSegmentIds =
             new ConcurrentHashMap<>();
     private KafkaProducer<String, Object> producer;
@@ -216,6 +217,7 @@ public class RLMMWithTopicStorage implements RemoteLogMetadataManager, RemoteLog
         return map == null || map.isEmpty() ? Optional.empty() : Optional.of(map.firstEntry().getKey());
     }
 
+    @Override
     public Optional<Long> highestLogOffset(TopicPartition topicPartition, int leaderEpoch) throws RemoteStorageException {
         ensureInitialized();
 

--- a/clients/src/test/java/org/apache/kafka/common/log/remote/storage/RemoteLogSegmentFileset.java
+++ b/clients/src/test/java/org/apache/kafka/common/log/remote/storage/RemoteLogSegmentFileset.java
@@ -224,7 +224,7 @@ public final class RemoteLogSegmentFileset {
     }
 
     public static boolean deleteFilesOnly(final Collection<File> files) {
-        final Optional<File> notAFile = files.stream().filter(f -> !f.isFile()).findAny();
+        final Optional<File> notAFile = files.stream().filter(f -> f.exists() && !f.isFile()).findAny();
 
         if (notAFile.isPresent()) {
             LOGGER.warn(format("Found unexpected directory %s. Will not delete.", notAFile.get().getAbsolutePath()));
@@ -237,8 +237,10 @@ public final class RemoteLogSegmentFileset {
     public static boolean deleteQuietly(final File file) {
         try {
             LOGGER.trace("Deleting " + file.getAbsolutePath());
+            if (!file.exists()) {
+                return true;
+            }
             return file.delete();
-
         } catch (final Exception e) {
             LOGGER.error(format("Encountered error while deleting %s", file.getAbsolutePath()));
         }

--- a/core/src/main/scala/kafka/log/Log.scala
+++ b/core/src/main/scala/kafka/log/Log.scala
@@ -299,9 +299,9 @@ class Log(@volatile private var _dir: File,
   // Visible for testing
   @volatile var leaderEpochCache: Option[LeaderEpochFileCache] = None
 
-  @volatile private var localLogStartOffset:Long = logStartOffset
+  @volatile private var localLogStartOffset: Long = logStartOffset
 
-  @volatile private var highestOffsetWithRemoteIndex:Long = logStartOffset
+  @volatile private var highestOffsetWithRemoteIndex: Long = -1L
 
   private def remoteLogEnabled() : Boolean = {
     // remote logging is enabled only for non-compact and non-internal topics

--- a/core/src/main/scala/kafka/log/ProducerStateManager.scala
+++ b/core/src/main/scala/kafka/log/ProducerStateManager.scala
@@ -503,6 +503,12 @@ class ProducerStateManager(val topicPartition: TopicPartition,
   // completed transactions whose markers are at offsets above the high watermark
   private val unreplicatedTxns = new util.TreeMap[Long, TxnMetadata]
 
+  def reloadSegments(): Unit = {
+    info("Reloading the producer state snapshots")
+    truncate()
+    snapshots = loadSnapshots()
+  }
+
   /**
    * Load producer state snapshots by scanning the _logDir.
    */

--- a/core/src/main/scala/kafka/server/KafkaConfig.scala
+++ b/core/src/main/scala/kafka/server/KafkaConfig.scala
@@ -138,7 +138,7 @@ object Defaults {
   val RemoteLogStorageEnable = false
   val RemoteStorageManager = ""
   val RemoteStorageManagerClassPath = ""
-  val RemoteLogRetentionMillis = 7 * 24 * 60 * 1000L
+  val RemoteLogRetentionMillis = 7 * 24 * 60 * 60 * 1000L
   val RemoteLogRetentionBytes = 1024 * 1024 * 1024L
   val RemoteLogManagerThreadPoolSize = 10
   val RemoteLogManagerTaskIntervalMs = 30 * 1000L

--- a/core/src/main/scala/kafka/server/ReplicaAlterLogDirsThread.scala
+++ b/core/src/main/scala/kafka/server/ReplicaAlterLogDirsThread.scala
@@ -295,4 +295,15 @@ class ReplicaAlterLogDirsThread(name: String,
     }
   }
 
+  override protected def buildRemoteLogAuxState(partition: TopicPartition,
+                                                currentLeaderEpoch: Int,
+                                                fetchOffset: Long,
+                                                leaderLogStartOffset: Long): Unit = {
+    // JBOD is not supported with tiered storage.
+    truncateFullyAndStartAt(partition, fetchOffset)
+    replicaMgr.futureLocalLogOrException(partition)
+      .maybeIncrementLogStartOffset(leaderLogStartOffset, LeaderOffsetIncremented)
+
+    // FIXME(@kamalcph): Confirm whether to rebuild the leader epoch and producer snapshots for future log.
+  }
 }

--- a/core/src/test/scala/kafka/tiered/storage/TieredStorageTests.scala
+++ b/core/src/test/scala/kafka/tiered/storage/TieredStorageTests.scala
@@ -20,7 +20,7 @@ package kafka.tiered.storage
 
 import java.util.Optional
 
-import kafka.tiered.storage.TieredStorageTests.{OffloadAndConsumeFromFollowerTest, OffloadAndConsumeFromLeaderTest}
+import kafka.tiered.storage.TieredStorageTests.{OffloadAndConsumeFromLeaderTest, CanFetchFromTieredStorageAfterRecoveryOfLocalSegmentsTest, OffloadAndConsumeFromFollowerTest}
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.internals.Topic
 import org.apache.kafka.common.replica.{ClientMetadata, PartitionView, ReplicaSelector, ReplicaView}
@@ -33,6 +33,7 @@ import scala.jdk.CollectionConverters._
 
 @SuiteClasses(Array[Class[_]](
   classOf[OffloadAndConsumeFromLeaderTest],
+  classOf[CanFetchFromTieredStorageAfterRecoveryOfLocalSegmentsTest],
   classOf[OffloadAndConsumeFromFollowerTest]
 ))
 @RunWith(classOf[Suite])

--- a/core/src/test/scala/unit/kafka/log/remote/RemoteIndexCacheTest.scala
+++ b/core/src/test/scala/unit/kafka/log/remote/RemoteIndexCacheTest.scala
@@ -55,7 +55,7 @@ class RemoteIndexCacheTest {
       .andReturn(new FileInputStream(File.createTempFile("kafka-test-", ".txnIndex")))
       .times(1)
     EasyMock.expect(rlsm.fetchProducerSnapshotIndex(EasyMock.anyObject(classOf[RemoteLogSegmentMetadata])))
-      .andReturn(new FileInputStream(File.createTempFile("kafka-test-", ".pid")))
+      .andReturn(new FileInputStream(File.createTempFile("kafka-test-", ".snapshot")))
       .times(1)
 
     EasyMock.replay(rlsm)

--- a/core/src/test/scala/unit/kafka/server/AbstractFetcherThreadTest.scala
+++ b/core/src/test/scala/unit/kafka/server/AbstractFetcherThreadTest.scala
@@ -479,6 +479,86 @@ class AbstractFetcherThreadTest {
   }
 
   @Test
+  def testFollowerFetchMovedToTieredStore(): Unit = {
+    val partition = new TopicPartition("topic", 0)
+    val fetcher = new MockFetcherThread()
+
+    val replicaLog = Seq(
+      mkBatch(baseOffset = 0, leaderEpoch = 0, new SimpleRecord("a".getBytes)),
+      mkBatch(baseOffset = 1, leaderEpoch = 2, new SimpleRecord("b".getBytes)),
+      mkBatch(baseOffset = 2, leaderEpoch = 4, new SimpleRecord("c".getBytes)))
+
+    val replicaState = MockFetcherThread.PartitionState(replicaLog, leaderEpoch = 5, highWatermark = 0L, rlmEnabled = true)
+    fetcher.setReplicaState(partition, replicaState)
+    fetcher.addPartitions(Map(partition -> initialFetchState(3L, leaderEpoch = 5)))
+
+    val leaderLog = Seq(
+      mkBatch(baseOffset = 5, leaderEpoch = 5, new SimpleRecord("f".getBytes)),
+      mkBatch(baseOffset = 6, leaderEpoch = 5, new SimpleRecord("g".getBytes)),
+      mkBatch(baseOffset = 7, leaderEpoch = 5, new SimpleRecord("h".getBytes)),
+      mkBatch(baseOffset = 8, leaderEpoch = 5, new SimpleRecord("i".getBytes)))
+
+
+    val leaderState = MockFetcherThread.PartitionState(leaderLog, leaderEpoch = 5, highWatermark = 8L, rlmEnabled = true)
+    // Overriding the log start offset to zero to mock the segment 0-4 moved to remote store.
+    leaderState.logStartOffset = 0
+    fetcher.setLeaderState(partition, leaderState)
+
+    assertEquals(3L, replicaState.logEndOffset)
+    assertEquals(Option(Fetching), fetcher.fetchState(partition).map(_.state))
+
+    fetcher.doWork()
+    // verify that the offset moved to tiered store error triggered and respective states are truncated to expected.
+    assertEquals(0L, replicaState.logStartOffset)
+    assertEquals(5L, replicaState.localLogStartOffset)
+    assertEquals(5L, replicaState.highWatermark)
+    assertEquals(5L, replicaState.logEndOffset)
+
+    // Only 1 record batch is returned after a poll so calling 'n' number of times to get the desired result.
+    for (_ <- 1 to 4) fetcher.doWork()
+    assertEquals(4, replicaState.log.size)
+    assertEquals(0L, replicaState.logStartOffset)
+    assertEquals(5L, replicaState.localLogStartOffset)
+    assertEquals(8L, replicaState.highWatermark)
+    assertEquals(9L, replicaState.logEndOffset)
+  }
+
+  @Test
+  def testFencedOffsetResetAfterMovedToRemoteTier(): Unit = {
+    val partition = new TopicPartition("topic", 0)
+    var isErrorHandled = false
+    val fetcher = new MockFetcherThread() {
+      override protected def buildRemoteLogAuxState(topicPartition: TopicPartition,
+                                                    leaderEpoch: Int,
+                                                    fetchOffset: Long,
+                                                    leaderLogStartOffset: Long): Unit = {
+        isErrorHandled = true
+        throw new FencedLeaderEpochException(s"Epoch $leaderEpoch is fenced")
+      }
+    }
+
+    val replicaLog = Seq(
+      mkBatch(baseOffset = 1, leaderEpoch = 2, new SimpleRecord("b".getBytes)),
+      mkBatch(baseOffset = 2, leaderEpoch = 4, new SimpleRecord("c".getBytes)))
+    val replicaState = MockFetcherThread.PartitionState(replicaLog, leaderEpoch = 5, highWatermark = 2L, rlmEnabled = true)
+    fetcher.setReplicaState(partition, replicaState)
+    fetcher.addPartitions(Map(partition -> initialFetchState(0L, leaderEpoch = 5)))
+
+    val leaderLog = Seq(
+      mkBatch(baseOffset = 5, leaderEpoch = 5, new SimpleRecord("b".getBytes)),
+      mkBatch(baseOffset = 6, leaderEpoch = 5, new SimpleRecord("c".getBytes)))
+    val leaderState = MockFetcherThread.PartitionState(leaderLog, leaderEpoch = 5, highWatermark = 6L, rlmEnabled = true)
+    fetcher.setLeaderState(partition, leaderState)
+
+    // After the offset moved to tiered storage error, we get a fenced error and remove the partition and mark as failed
+    fetcher.doWork()
+    assertEquals(3, replicaState.logEndOffset)
+    assertTrue(isErrorHandled)
+    assertTrue(fetcher.fetchState(partition).isEmpty)
+    assertTrue(failedPartitions.contains(partition))
+  }
+
+  @Test
   def testFencedOffsetResetAfterOutOfRange(): Unit = {
     val partition = new TopicPartition("topic", 0)
     var fetchedEarliestOffset = false
@@ -852,13 +932,19 @@ class AbstractFetcherThreadTest {
                          var leaderEpoch: Int,
                          var logStartOffset: Long,
                          var logEndOffset: Long,
-                         var highWatermark: Long)
+                         var highWatermark: Long,
+                         var rlmEnabled: Boolean,
+                         var localLogStartOffset: Long)
 
     object PartitionState {
-      def apply(log: Seq[RecordBatch], leaderEpoch: Int, highWatermark: Long): PartitionState = {
+      def apply(log: Seq[RecordBatch], leaderEpoch: Int, highWatermark: Long, rlmEnabled: Boolean): PartitionState = {
         val logStartOffset = log.headOption.map(_.baseOffset).getOrElse(0L)
         val logEndOffset = log.lastOption.map(_.nextOffset).getOrElse(0L)
-        new PartitionState(log.toBuffer, leaderEpoch, logStartOffset, logEndOffset, highWatermark)
+        new PartitionState(log.toBuffer, leaderEpoch, logStartOffset, logEndOffset, highWatermark, rlmEnabled, logStartOffset)
+      }
+
+      def apply(log: Seq[RecordBatch], leaderEpoch: Int, highWatermark: Long): PartitionState = {
+        apply(log, leaderEpoch, highWatermark, rlmEnabled = false)
       }
 
       def apply(leaderEpoch: Int): PartitionState = {
@@ -975,7 +1061,11 @@ class AbstractFetcherThreadTest {
     override def truncateFullyAndStartAt(topicPartition: TopicPartition, offset: Long): Unit = {
       val state = replicaPartitionState(topicPartition)
       state.log.clear()
-      state.logStartOffset = offset
+      if (state.rlmEnabled) {
+        state.localLogStartOffset = offset
+      } else {
+        state.logStartOffset = offset
+      }
       state.logEndOffset = offset
       state.highWatermark = offset
     }
@@ -1127,8 +1217,12 @@ class AbstractFetcherThreadTest {
 
         val (error, records) = if (epochCheckError.isDefined) {
           (epochCheckError.get, MemoryRecords.EMPTY)
-        } else if (fetchData.fetchOffset > leaderState.logEndOffset || fetchData.fetchOffset < leaderState.logStartOffset) {
-          (Errors.OFFSET_OUT_OF_RANGE, MemoryRecords.EMPTY)
+        } else if (fetchData.fetchOffset > leaderState.logEndOffset || fetchData.fetchOffset < leaderState.localLogStartOffset) {
+          if (leaderState.rlmEnabled && fetchData.fetchOffset < leaderState.localLogStartOffset) {
+            (Errors.OFFSET_MOVED_TO_TIERED_STORAGE, MemoryRecords.EMPTY)
+          } else {
+            (Errors.OFFSET_OUT_OF_RANGE, MemoryRecords.EMPTY)
+          }
         } else if (divergingEpoch.nonEmpty) {
           (Errors.NONE, MemoryRecords.EMPTY)
         } else {
@@ -1161,7 +1255,7 @@ class AbstractFetcherThreadTest {
     override protected def fetchEarliestOffsetFromLeader(topicPartition: TopicPartition, leaderEpoch: Int): Long = {
       val leaderState = leaderPartitionState(topicPartition)
       checkLeaderEpochAndThrow(leaderEpoch, leaderState)
-      leaderState.logStartOffset
+      leaderState.localLogStartOffset
     }
 
     override protected def fetchLatestOffsetFromLeader(topicPartition: TopicPartition, leaderEpoch: Int): Long = {
@@ -1170,6 +1264,14 @@ class AbstractFetcherThreadTest {
       leaderState.logEndOffset
     }
 
+    override protected def buildRemoteLogAuxState(topicPartition: TopicPartition,
+                                                  currentLeaderEpoch: Int,
+                                                  fetchOffset: Long,
+                                                  leaderLogStartOffset: Long): Unit = {
+      truncateFullyAndStartAt(topicPartition, fetchOffset)
+      replicaPartitionState(topicPartition).logStartOffset = leaderLogStartOffset
+      // skipped building leader epoch cache and producer snapshots as they are not verified.
+    }
   }
 
 }

--- a/core/src/test/scala/unit/kafka/server/epoch/LeaderEpochFileCacheTest.scala
+++ b/core/src/test/scala/unit/kafka/server/epoch/LeaderEpochFileCacheTest.scala
@@ -571,4 +571,18 @@ class LeaderEpochFileCacheTest {
     cache.truncateFromEnd(7)
   }
 
+  @Test
+  def shouldFetchEpochForGivenOffset(): Unit = {
+    cache.assign(0, 10L)
+    cache.assign(1, 20L)
+    cache.assign(5, 30L)
+
+    assertEquals(1, cache.epochForOffset(25L).get)
+    assertEquals(1, cache.epochForOffset(20L).get)
+    assertEquals(5, cache.epochForOffset(30L).get)
+    assertEquals(5, cache.epochForOffset(50L).get)
+    assertEquals(0, cache.epochForOffset(5L).get)
+    cache.clearAndFlush()
+  }
+
 }


### PR DESCRIPTION
**What this patch about?**
When the follower comes up with empty storage / behind the leader's log start offset, it reconciles the state with the remote tier and starts to fetch records from the leader's local log start offset and continue there-after.

**Testing done**
* Written a unit test in AbstractFetcherThread to verify whether the respective states are being updated correctly after the truncation of local log segments in the replica.
* Integration test which stops the follower, removes the disk storage, and restarts it. And, consumes the records from the restarted node by making it the new leader.

**Pending**
* To write an integration test that verifies whether the transaction producer is able to proceed when restoring the snapshots from the remote tier.
* When unclean leader election is enabled including truncation ([scenario-4](https://cwiki.apache.org/confluence/display/KAFKA/KIP-405%3A+Kafka+Tiered+Storage#KIP405:KafkaTieredStorage-Scenario4:uncleanleaderelectionincludingtruncation.)).