### PR TITLE
Enhance HDFS RSM to upload all the index and segment files.

### DIFF
--- a/clients/src/main/java/org/apache/kafka/common/log/remote/storage/LogSegmentData.java
+++ b/clients/src/main/java/org/apache/kafka/common/log/remote/storage/LogSegmentData.java
@@ -17,6 +17,7 @@
 package org.apache.kafka.common.log.remote.storage;
 
 import java.io.File;
+import java.util.Objects;
 
 public class LogSegmentData {
 
@@ -59,5 +60,30 @@ public class LogSegmentData {
 
     public File leaderEpochCheckpoint() {
         return leaderEpochCheckpoint;
+    }
+
+    @Override
+    public String toString() {
+        return "LogSegmentData{" +
+                "logSegment=" + logSegment +
+                ", offsetIndex=" + offsetIndex +
+                ", timeIndex=" + timeIndex +
+                ", txnIndex=" + txnIndex +
+                ", producerIdSnapshotIndex=" + producerIdSnapshotIndex +
+                ", leaderEpochCheckpoint=" + leaderEpochCheckpoint +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        LogSegmentData that = (LogSegmentData) o;
+        return Objects.equals(logSegment, that.logSegment) && Objects.equals(offsetIndex, that.offsetIndex) && Objects.equals(timeIndex, that.timeIndex) && Objects.equals(txnIndex, that.txnIndex) && Objects.equals(producerIdSnapshotIndex, that.producerIdSnapshotIndex) && Objects.equals(leaderEpochCheckpoint, that.leaderEpochCheckpoint);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(logSegment, offsetIndex, timeIndex, txnIndex, producerIdSnapshotIndex, leaderEpochCheckpoint);
     }
 }

--- a/remote-storage-managers/hdfs/src/main/java/org/apache/kafka/rsm/hdfs/HDFSRemoteStorageManager.java
+++ b/remote-storage-managers/hdfs/src/main/java/org/apache/kafka/rsm/hdfs/HDFSRemoteStorageManager.java
@@ -83,7 +83,8 @@ public class HDFSRemoteStorageManager implements RemoteStorageManager {
         }
         readCache = new LRUCache(cacheSize);
 
-        hadoopConf = new Configuration(); // Load configuration from hadoop configuration files in class path
+        // Loads configuration from hadoop configuration files in class path
+        hadoopConf = new Configuration();
     }
 
     @Override
@@ -93,7 +94,6 @@ public class HDFSRemoteStorageManager implements RemoteStorageManager {
             final Path dirPath = new Path(getSegmentRemoteDir(metadata.remoteLogSegmentId()));
             final FSDataOutputStream fsOut = getFS().create(dirPath);
 
-            // copy local files to remote temporary directory
             fsOut.write(LogSegmentDataHeader.serialize(header), 0, LogSegmentDataHeader.LENGTH);
             uploadFile(segmentData.offsetIndex(), fsOut, false);
             uploadFile(segmentData.timeIndex(), fsOut, false);

--- a/remote-storage-managers/hdfs/src/main/java/org/apache/kafka/rsm/hdfs/HDFSRemoteStorageManager.java
+++ b/remote-storage-managers/hdfs/src/main/java/org/apache/kafka/rsm/hdfs/HDFSRemoteStorageManager.java
@@ -30,7 +30,10 @@ import org.apache.kafka.common.log.remote.storage.RemoteStorageException;
 import org.apache.kafka.common.log.remote.storage.RemoteStorageManager;
 import org.apache.kafka.common.utils.Utils;
 
-import java.io.*;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
 import java.nio.ByteBuffer;
 import java.util.Map;
@@ -38,7 +41,12 @@ import java.util.Map;
 import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.IO_FILE_BUFFER_SIZE_DEFAULT;
 import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.IO_FILE_BUFFER_SIZE_KEY;
 
-import static org.apache.kafka.rsm.hdfs.LogSegmentDataHeader.FileType.*;
+import static org.apache.kafka.rsm.hdfs.LogSegmentDataHeader.FileType.LEADER_EPOCH_CHECKPOINT;
+import static org.apache.kafka.rsm.hdfs.LogSegmentDataHeader.FileType.OFFSET_INDEX;
+import static org.apache.kafka.rsm.hdfs.LogSegmentDataHeader.FileType.PRODUCER_SNAPSHOT;
+import static org.apache.kafka.rsm.hdfs.LogSegmentDataHeader.FileType.SEGMENT;
+import static org.apache.kafka.rsm.hdfs.LogSegmentDataHeader.FileType.TIMESTAMP_INDEX;
+import static org.apache.kafka.rsm.hdfs.LogSegmentDataHeader.FileType.TRANSACTION_INDEX;
 
 public class HDFSRemoteStorageManager implements RemoteStorageManager {
 

--- a/remote-storage-managers/hdfs/src/main/java/org/apache/kafka/rsm/hdfs/HDFSRemoteStorageManager.java
+++ b/remote-storage-managers/hdfs/src/main/java/org/apache/kafka/rsm/hdfs/HDFSRemoteStorageManager.java
@@ -90,11 +90,12 @@ public class HDFSRemoteStorageManager implements RemoteStorageManager {
     @Override
     public void copyLogSegment(RemoteLogSegmentMetadata metadata, LogSegmentData segmentData) throws RemoteStorageException {
         try {
-            final LogSegmentDataHeader header = LogSegmentDataHeader.create(segmentData);
             final Path dirPath = new Path(getSegmentRemoteDir(metadata.remoteLogSegmentId()));
             final FSDataOutputStream fsOut = getFS().create(dirPath);
 
-            fsOut.write(LogSegmentDataHeader.serialize(header), 0, LogSegmentDataHeader.LENGTH);
+            final LogSegmentDataHeader header = LogSegmentDataHeader.create(segmentData);
+            byte[] serializedHeader = LogSegmentDataHeader.serialize(header);
+            fsOut.write(serializedHeader, 0, serializedHeader.length);
             uploadFile(segmentData.offsetIndex(), fsOut, false);
             uploadFile(segmentData.timeIndex(), fsOut, false);
             uploadFile(segmentData.leaderEpochCheckpoint(), fsOut, false);

--- a/remote-storage-managers/hdfs/src/main/java/org/apache/kafka/rsm/hdfs/HDFSRemoteStorageManager.java
+++ b/remote-storage-managers/hdfs/src/main/java/org/apache/kafka/rsm/hdfs/HDFSRemoteStorageManager.java
@@ -17,8 +17,10 @@
 package org.apache.kafka.rsm.hdfs;
 
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.kafka.common.log.remote.storage.LogSegmentData;
@@ -26,84 +28,106 @@ import org.apache.kafka.common.log.remote.storage.RemoteLogSegmentId;
 import org.apache.kafka.common.log.remote.storage.RemoteLogSegmentMetadata;
 import org.apache.kafka.common.log.remote.storage.RemoteStorageException;
 import org.apache.kafka.common.log.remote.storage.RemoteStorageManager;
+import org.apache.kafka.common.utils.Utils;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
+import java.io.*;
 import java.net.URI;
+import java.nio.ByteBuffer;
 import java.util.Map;
+
+import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.IO_FILE_BUFFER_SIZE_DEFAULT;
+import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.IO_FILE_BUFFER_SIZE_KEY;
+
+import static org.apache.kafka.rsm.hdfs.LogSegmentDataHeader.FileType.*;
 
 public class HDFSRemoteStorageManager implements RemoteStorageManager {
 
-    private static final String LOG_FILE_NAME = "log";
-    private static final String OFFSET_INDEX_FILE_NAME = "index";
-    private static final String TIME_INDEX_FILE_NAME = "timeindex";
+    public static final String LOG_FILE_NAME = "log";
+    public static final String OFFSET_INDEX_FILE_NAME = "index";
+    public static final String TIME_INDEX_FILE_NAME = "time";
+    public static final String LEADER_EPOCH_FILE_NAME = "leader-epoch-checkpoint";
+    public static final String TXN_INDEX_FILE_NAME = "txn";
+    public static final String PRODUCER_SNAPSHOT_FILE_NAME = "snapshot";
 
     private URI fsURI = null;
     private String baseDir = null;
     private Configuration hadoopConf = null;
-    private ThreadLocal<FileSystem> fs = new ThreadLocal<>();
+    private final ThreadLocal<FileSystem> fs = new ThreadLocal<>();
     private int cacheLineSize;
     private LRUCache readCache;
 
+    /**
+     * Initialize this instance with the given configs
+     *
+     * @param configs Key-Value pairs of configuration parameters
+     */
     @Override
-    public void copyLogSegment(RemoteLogSegmentMetadata remoteLogSegmentMetadata, LogSegmentData logSegmentData) throws RemoteStorageException {
+    public void configure(Map<String, ?> configs) {
+        HDFSRemoteStorageManagerConfig conf = new HDFSRemoteStorageManagerConfig(configs, true);
+
+        fsURI = URI.create(conf.getString(HDFSRemoteStorageManagerConfig.HDFS_URI_PROP));
+        baseDir = conf.getString(HDFSRemoteStorageManagerConfig.HDFS_BASE_DIR_PROP);
+        cacheLineSize = conf.getInt(HDFSRemoteStorageManagerConfig.HDFS_REMOTE_READ_MB_PROP) * 1048576;
+        long cacheSize = conf.getInt(HDFSRemoteStorageManagerConfig.HDFS_REMOTE_READ_CACHE_MB_PROP) * 1048576L;
+        if (cacheSize < cacheLineSize) {
+            throw new IllegalArgumentException(HDFSRemoteStorageManagerConfig.HDFS_REMOTE_READ_MB_PROP +
+                    " is larger than " + HDFSRemoteStorageManagerConfig.HDFS_REMOTE_READ_CACHE_MB_PROP);
+        }
+        readCache = new LRUCache(cacheSize);
+
+        hadoopConf = new Configuration(); // Load configuration from hadoop configuration files in class path
+    }
+
+    @Override
+    public void copyLogSegment(RemoteLogSegmentMetadata metadata, LogSegmentData segmentData) throws RemoteStorageException {
         try {
-            String desDir = getSegmentRemoteDir(remoteLogSegmentMetadata.remoteLogSegmentId());
-
-            File logFile = logSegmentData.logSegment();
-            File offsetIdxFile = logSegmentData.offsetIndex();
-            File tsIdxFile = logSegmentData.timeIndex();
-
-            FileSystem fs = getFS();
-            fs.mkdirs(new Path(desDir));
+            final LogSegmentDataHeader header = LogSegmentDataHeader.create(segmentData);
+            final Path dirPath = new Path(getSegmentRemoteDir(metadata.remoteLogSegmentId()));
+            final FSDataOutputStream fsOut = getFS().create(dirPath);
 
             // copy local files to remote temporary directory
-            copyFile(fs, logFile, getPath(desDir, LOG_FILE_NAME));
-            copyFile(fs, offsetIdxFile, getPath(desDir, OFFSET_INDEX_FILE_NAME));
-            copyFile(fs, tsIdxFile, getPath(desDir, TIME_INDEX_FILE_NAME));
+            fsOut.write(LogSegmentDataHeader.serialize(header), 0, LogSegmentDataHeader.LENGTH);
+            uploadFile(segmentData.offsetIndex(), fsOut, false);
+            uploadFile(segmentData.timeIndex(), fsOut, false);
+            uploadFile(segmentData.leaderEpochCheckpoint(), fsOut, false);
+            uploadFile(segmentData.producerIdSnapshotIndex(), fsOut, false);
+            uploadFile(segmentData.txnIndex(), fsOut, false);
+            uploadFile(segmentData.logSegment(), fsOut, true);
         } catch (Exception e) {
             throw new RemoteStorageException("Failed to copy log segment to remote storage", e);
         }
     }
 
-    private void copyFile(FileSystem fs, File localFile, Path path) throws IOException {
-        fs.copyFromLocalFile(new Path(localFile.getAbsolutePath()), path);
-        // keep the original mtime. we will use the mtime to calculate retention time
-        fs.setTimes(path, localFile.lastModified(), System.currentTimeMillis());
+    @Override
+    public InputStream fetchLogSegmentData(RemoteLogSegmentMetadata metadata,
+                                           Long startPosition,
+                                           Long endPosition) throws RemoteStorageException {
+        return fetchData(metadata, SEGMENT, startPosition, endPosition);
     }
 
     @Override
-    public InputStream fetchLogSegmentData(RemoteLogSegmentMetadata remoteLogSegmentMetadata, Long startPosition, Long endPosition) throws RemoteStorageException {
-        try {
-            String path = getSegmentRemoteDir(remoteLogSegmentMetadata.remoteLogSegmentId());
-            Path logFile = getPath(path, LOG_FILE_NAME);
-            return new CachedInputStream(logFile, startPosition, endPosition);
-        } catch (Exception e) {
-            throw new RemoteStorageException("Failed to fetch remote log segment", e);
-        }
+    public InputStream fetchOffsetIndex(RemoteLogSegmentMetadata metadata) throws RemoteStorageException {
+        return fetchData(metadata, OFFSET_INDEX, 0, Long.MAX_VALUE);
     }
 
     @Override
-    public InputStream fetchOffsetIndex(RemoteLogSegmentMetadata remoteLogSegmentMetadata) throws RemoteStorageException {
-        try {
-            String path = getSegmentRemoteDir(remoteLogSegmentMetadata.remoteLogSegmentId());
-            Path indexFile = getPath(path, OFFSET_INDEX_FILE_NAME);
-            return new CachedInputStream(indexFile, 0, Long.MAX_VALUE);
-        } catch (Exception e) {
-            throw new RemoteStorageException("Failed to fetch offset index from remote storage", e);
-        }
+    public InputStream fetchTimestampIndex(RemoteLogSegmentMetadata metadata) throws RemoteStorageException {
+        return fetchData(metadata, TIMESTAMP_INDEX, 0, Long.MAX_VALUE);
     }
 
     @Override
-    public InputStream fetchTimestampIndex(RemoteLogSegmentMetadata remoteLogSegmentMetadata) throws RemoteStorageException {
-        try {
-            String path = getSegmentRemoteDir(remoteLogSegmentMetadata.remoteLogSegmentId());
-            Path timeindexFile = getPath(path, TIME_INDEX_FILE_NAME);
-            return new CachedInputStream(timeindexFile, 0, Long.MAX_VALUE);
-        } catch (Exception e) {
-            throw new RemoteStorageException("Failed to fetch timestamp index from remote storage", e);
-        }
+    public InputStream fetchTransactionIndex(RemoteLogSegmentMetadata metadata) throws RemoteStorageException {
+        return fetchData(metadata, TRANSACTION_INDEX, 0, Long.MAX_VALUE);
+    }
+
+    @Override
+    public InputStream fetchProducerSnapshotIndex(RemoteLogSegmentMetadata metadata) throws RemoteStorageException {
+        return fetchData(metadata, PRODUCER_SNAPSHOT, 0, Long.MAX_VALUE);
+    }
+
+    @Override
+    public InputStream fetchLeaderEpochIndex(RemoteLogSegmentMetadata metadata) throws RemoteStorageException {
+        return fetchData(metadata, LEADER_EPOCH_CHECKPOINT, 0, Long.MAX_VALUE);
     }
 
     @Override
@@ -111,30 +135,118 @@ public class HDFSRemoteStorageManager implements RemoteStorageManager {
         boolean delete;
         try {
             String path = getSegmentRemoteDir(remoteLogSegmentMetadata.remoteLogSegmentId());
-
             delete = getFS().delete(new Path(path), true);
         } catch (Exception e) {
             throw new RemoteStorageException("Failed to delete remote log segment with id:" +
                     remoteLogSegmentMetadata.remoteLogSegmentId(), e);
         }
-
         if (!delete) {
-            throw new RemoteStorageException("Failed to delete remote log segment with id:" +
+            throw new RemoteStorageException("Failed to delete remote log segment with id: " +
                     remoteLogSegmentMetadata.remoteLogSegmentId());
         }
     }
 
-    private class CachedInputStream extends InputStream {
-        private Path logFile;
-        private long currentPos;
-        private long fileLen;
-        private FSDataInputStream inputStream;
+    @Override
+    public void close() {
+        Utils.closeQuietly(fs.get(), "Hadoop file system");
+    }
 
-        CachedInputStream(Path logFile, long currentPos, long endPos) throws IOException {
-            this.logFile = logFile;
-            this.currentPos = currentPos;
+    @VisibleForTesting
+    void setLRUCache(final LRUCache cache) {
+        this.readCache = cache;
+    }
+
+    private void uploadFile(final File localSrc,
+                            final FSDataOutputStream out,
+                            final boolean closeStream) throws IOException {
+        if (localSrc != null && localSrc.exists()) {
+            final int bufferSize = hadoopConf.getInt(IO_FILE_BUFFER_SIZE_KEY, IO_FILE_BUFFER_SIZE_DEFAULT);
+            final byte[] buf = new byte[bufferSize];
+            try (final FileInputStream fis = new FileInputStream(localSrc)) {
+                int bytesRead = fis.read(buf);
+                while (bytesRead >= 0) {
+                    out.write(buf, 0, bytesRead);
+                    bytesRead = fis.read(buf);
+                }
+            }
+            if (closeStream && out != null) {
+                out.flush();
+                Utils.closeAll(out);
+            }
+        }
+    }
+
+    private InputStream fetchData(RemoteLogSegmentMetadata metadata,
+                                  LogSegmentDataHeader.FileType fileType,
+                                  long startPosition,
+                                  long endPosition) throws RemoteStorageException {
+        try {
+            Path dataFilePath = new Path(getSegmentRemoteDir(metadata.remoteLogSegmentId()));
+            return new CachedInputStream(dataFilePath, fileType, startPosition, addExact(endPosition, 1L));
+        } catch (Exception e) {
+            throw new RemoteStorageException(
+                    String.format("Failed to fetch %s file from remote storage", fileType), e);
+        }
+    }
+
+    private FileSystem getFS() throws IOException {
+        if (fs.get() == null) {
+            fs.set(FileSystem.newInstance(fsURI, hadoopConf));
+        }
+        return fs.get();
+    }
+
+    private String getSegmentRemoteDir(RemoteLogSegmentId remoteLogSegmentId) {
+        return baseDir + "/" + remoteLogSegmentId.topicPartition() + "/" + remoteLogSegmentId.id();
+    }
+
+    private long addExact(long base, long increment) {
+        try {
+            base = Math.addExact(base, increment);
+        } catch (final ArithmeticException swallow) {
+            base = Long.MAX_VALUE;
+        }
+        return base;
+    }
+
+    private class CachedInputStream extends InputStream {
+        private final Path dataPath;
+        private final long fileLen;
+        private long currentPos;
+        private FSDataInputStream inputStream;
+        private final boolean fullFetch;
+
+        /**
+         * Input Stream which caches the data to serve them locally on repeated reads.
+         * @param dataPath   path of the data file.
+         * @param fileType   type of the file.
+         * @param currentPos current position to read from the stream, inclusive.
+         * @param endPos     to read upto the end position, exclusive.
+         * @throws IOException IO problems
+         */
+        CachedInputStream(Path dataPath,
+                          LogSegmentDataHeader.FileType fileType,
+                          long currentPos,
+                          long endPos) throws IOException {
+            this.dataPath = dataPath;
+
             FileSystem fs = getFS();
-            fileLen = Math.min(fs.getFileStatus(logFile).getLen(), endPos);
+            // Sends a remote fetch to read the file header.
+            inputStream = fs.open(dataPath);
+            byte[] buffer = new byte[LogSegmentDataHeader.LENGTH];
+            inputStream.readFully(0, buffer);
+
+            LogSegmentDataHeader.DataPosition dataPosition = LogSegmentDataHeader
+                    .deserialize(ByteBuffer.wrap(buffer))
+                    .getDataPosition(fileType);
+            this.currentPos = addExact(currentPos, dataPosition.getPos());
+            endPos = addExact(endPos, dataPosition.getPos());
+
+            long actualFileLength = fs.getFileStatus(dataPath).getLen();
+            fileLen = (dataPosition.getLength() == Integer.MAX_VALUE) ?
+                    Math.min(endPos, actualFileLength) :
+                    Math.min(endPos, dataPosition.getPos() + dataPosition.getLength());
+            fullFetch = (fileLen == actualFileLength);
         }
 
         @Override
@@ -167,7 +279,7 @@ public class HDFSRemoteStorageManager implements RemoteStorageManager {
         }
 
         @Override
-        public int available() throws IOException {
+        public int available() {
             long available = fileLen - currentPos;
             if (available > Integer.MAX_VALUE)
                 return Integer.MAX_VALUE;
@@ -178,75 +290,24 @@ public class HDFSRemoteStorageManager implements RemoteStorageManager {
         private byte[] getCachedData(long position) throws IOException {
             long pos = (position / cacheLineSize) * cacheLineSize;
 
-            byte[] data = readCache.get(logFile.toString(), pos);
+            byte[] data = readCache.get(dataPath.toString(), pos);
             if (data != null)
                 return data;
 
-            if (inputStream == null) {
-                FileSystem fs = getFS();
-                inputStream = fs.open(logFile);
-            }
             long dataLength = Math.min(cacheLineSize, fileLen - pos);
             data = new byte[(int) dataLength];
             inputStream.readFully(pos, data);
-            readCache.put(logFile.toString(), pos, data);
+            // To avoid intermediate results being stored in cache, save only full fetch request results.
+            if (fullFetch || dataLength == cacheLineSize) {
+                readCache.put(dataPath.toString(), pos, data);
+            }
             return data;
         }
 
         @Override
         public void close() throws IOException {
-            if (inputStream != null) {
-                inputStream.close();
-                inputStream = null;
-            }
+            Utils.closeAll(inputStream);
+            inputStream = null;
         }
-    }
-
-    @Override
-    public void close() {
-        if (fs.get() != null) {
-            try {
-                fs.get().close();
-            } catch (IOException e) {
-            }
-        }
-    }
-
-    /**
-     * Initialize this instance with the given configs
-     *
-     * @param configs Key-Value pairs of configuration parameters
-     */
-    @Override
-    public void configure(Map<String, ?> configs) {
-        HDFSRemoteStorageManagerConfig conf = new HDFSRemoteStorageManagerConfig(configs, true);
-
-        fsURI = URI.create(conf.getString(HDFSRemoteStorageManagerConfig.HDFS_URI_PROP));
-        baseDir = conf.getString(HDFSRemoteStorageManagerConfig.HDFS_BASE_DIR_PROP);
-        cacheLineSize = conf.getInt(HDFSRemoteStorageManagerConfig.HDFS_REMOTE_READ_MB_PROP) * 1048576;
-        long cacheSize = conf.getInt(HDFSRemoteStorageManagerConfig.HDFS_REMOTE_READ_CACHE_MB_PROP) * 1048576L;
-        if (cacheSize < cacheLineSize) {
-            throw new IllegalArgumentException(HDFSRemoteStorageManagerConfig.HDFS_REMOTE_READ_MB_PROP +
-                " is larger than " + HDFSRemoteStorageManagerConfig.HDFS_REMOTE_READ_CACHE_MB_PROP);
-        }
-        readCache = new LRUCache(cacheSize);
-
-        hadoopConf = new Configuration(); // Load configuration from hadoop configuration files in class path
-    }
-
-    private FileSystem getFS() throws IOException {
-        if (fs.get() == null) {
-            fs.set(FileSystem.newInstance(fsURI, hadoopConf));
-        }
-
-        return fs.get();
-    }
-
-    private String getSegmentRemoteDir(RemoteLogSegmentId remoteLogSegmentId) {
-        return baseDir + "/" + remoteLogSegmentId.topicPartition() + "/" + remoteLogSegmentId.id();
-    }
-
-    private Path getPath(String dirPath, String fileName) {
-        return new Path(dirPath + "/" + fileName);
     }
 }

--- a/remote-storage-managers/hdfs/src/main/java/org/apache/kafka/rsm/hdfs/LogSegmentDataHeader.java
+++ b/remote-storage-managers/hdfs/src/main/java/org/apache/kafka/rsm/hdfs/LogSegmentDataHeader.java
@@ -1,0 +1,205 @@
+package org.apache.kafka.rsm.hdfs;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.apache.kafka.common.errors.UnsupportedVersionException;
+import org.apache.kafka.common.log.remote.storage.LogSegmentData;
+
+import java.io.File;
+import java.nio.ByteBuffer;
+import java.util.EnumMap;
+import java.util.Objects;
+
+public class LogSegmentDataHeader {
+
+    public enum FileType {
+        // NOTE: DONT CHANGE THE ORDER OF THE FILE TYPES. Once a new file type is added, make sure to change the version
+        // and handle the SERDE for backward compatibility.
+        OFFSET_INDEX((byte) 0),
+        TIMESTAMP_INDEX((byte) 1),
+        LEADER_EPOCH_CHECKPOINT((byte) 2),
+        PRODUCER_SNAPSHOT((byte) 3),
+        TRANSACTION_INDEX((byte) 4),
+        SEGMENT((byte) 5);
+
+        private final byte id;
+
+        FileType(byte id) {
+            this.id = id;
+        }
+
+        public static FileType fromId(byte id) {
+            switch (id) {
+                case 0:
+                    return OFFSET_INDEX;
+                case 1:
+                    return TIMESTAMP_INDEX;
+                case 2:
+                    return LEADER_EPOCH_CHECKPOINT;
+                case 3:
+                    return PRODUCER_SNAPSHOT;
+                case 4:
+                    return TRANSACTION_INDEX;
+                case 5:
+                    return SEGMENT;
+                default:
+                    return null;
+            }
+        }
+    }
+
+    public static final Integer LENGTH = 25;
+    public static final byte CURRENT_VERSION = 0;
+
+    private byte version;
+    private final EnumMap<FileType, Integer> filePositions = new EnumMap<>(FileType.class);
+
+    private LogSegmentDataHeader() {
+    }
+
+    @VisibleForTesting
+    byte version() {
+        return version;
+    }
+
+    @VisibleForTesting
+    EnumMap<FileType, Integer> filePositions() {
+        return filePositions;
+    }
+
+    public DataPosition getDataPosition(final FileType fileType) {
+        final Integer position = filePositions.get(fileType);
+        switch (fileType) {
+            case OFFSET_INDEX:
+            case TIMESTAMP_INDEX:
+            case LEADER_EPOCH_CHECKPOINT:
+            case PRODUCER_SNAPSHOT:
+            case TRANSACTION_INDEX:
+                final FileType nextFileType = FileType.fromId((byte) (fileType.id+1));
+                final int nextFilePosition = filePositions.get(nextFileType);
+                final int length = nextFilePosition - position;
+                return new DataPosition(position, length);
+            case SEGMENT:
+                return new DataPosition(position, Integer.MAX_VALUE);
+            default:
+                return null;
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "LogSegmentDataHeader{" +
+                "version=" + version +
+                ", filePositions=" + filePositions +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        LogSegmentDataHeader that = (LogSegmentDataHeader) o;
+        return version == that.version && Objects.equals(filePositions, that.filePositions);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(version, filePositions);
+    }
+
+    public static byte[] serialize(final LogSegmentDataHeader header) {
+        final byte[] buf = new byte[LENGTH];
+        final ByteBuffer byteBuffer = ByteBuffer.wrap(buf);
+        byteBuffer.put(header.version);
+        for (final FileType fileType : FileType.values()) {
+            byteBuffer.putInt(header.filePositions.get(fileType));
+        }
+        return buf;
+    }
+
+    public static LogSegmentDataHeader deserialize(final ByteBuffer buffer) {
+        final LogSegmentDataHeader dataHeader = new LogSegmentDataHeader();
+        dataHeader.version = buffer.get();
+        if (dataHeader.version != CURRENT_VERSION) {
+            throw new UnsupportedVersionException("Unsupported version!");
+        }
+        for (final FileType fileType : FileType.values()) {
+            dataHeader.filePositions.put(fileType, buffer.getInt());
+        }
+        return dataHeader;
+    }
+
+    public static LogSegmentDataHeader create(final LogSegmentData segmentData) {
+        final LogSegmentDataHeader header = new LogSegmentDataHeader();
+        header.version = CURRENT_VERSION;
+        int startPos = LENGTH;
+        for (final FileType fileType : FileType.values()) {
+            long length = 0L;
+            final File file = getFile(segmentData, fileType);
+            if (file != null) {
+                length += file.length();
+            }
+            header.filePositions.put(fileType, startPos);
+            startPos += (int) length;
+        }
+        return header;
+    }
+
+    private static File getFile(final LogSegmentData segmentData,
+                                final FileType type) {
+        switch (type) {
+            case OFFSET_INDEX:
+                return segmentData.offsetIndex();
+            case TIMESTAMP_INDEX:
+                return segmentData.timeIndex();
+            case LEADER_EPOCH_CHECKPOINT:
+                return segmentData.leaderEpochCheckpoint();
+            case PRODUCER_SNAPSHOT:
+                return segmentData.producerIdSnapshotIndex();
+            case TRANSACTION_INDEX:
+                return segmentData.txnIndex();
+            case SEGMENT:
+                return segmentData.logSegment();
+            default:
+                return null;
+        }
+    }
+
+    public static class DataPosition {
+        private final int pos;
+        private final int length;
+
+        public DataPosition(final int pos, final int length) {
+            this.pos = pos;
+            this.length = length;
+        }
+
+        public int getPos() {
+            return pos;
+        }
+
+        public int getLength() {
+            return length;
+        }
+
+        @Override
+        public String toString() {
+            return "DataPosition{" +
+                    "pos=" + pos +
+                    ", length=" + length +
+                    '}';
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            DataPosition that = (DataPosition) o;
+            return pos == that.pos && length == that.length;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(pos, length);
+        }
+    }
+}

--- a/remote-storage-managers/hdfs/src/main/java/org/apache/kafka/rsm/hdfs/LogSegmentDataHeader.java
+++ b/remote-storage-managers/hdfs/src/main/java/org/apache/kafka/rsm/hdfs/LogSegmentDataHeader.java
@@ -81,7 +81,7 @@ public class LogSegmentDataHeader {
             case SEGMENT:
                 return new DataPosition(position, Integer.MAX_VALUE);
             default:
-                return null;
+                throw new IllegalArgumentException(String.format("FileType %s is invalid", fileType));
         }
     }
 

--- a/remote-storage-managers/hdfs/src/test/java/org/apache/kafka/rsm/hdfs/HDFSRemoteStorageManagerTest.java
+++ b/remote-storage-managers/hdfs/src/test/java/org/apache/kafka/rsm/hdfs/HDFSRemoteStorageManagerTest.java
@@ -16,59 +16,58 @@
  */
 package org.apache.kafka.rsm.hdfs;
 
-import kafka.log.LogSegment;
-import kafka.log.LogUtils;
-import kafka.utils.TestUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.RemoteIterator;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.log.remote.storage.LogSegmentData;
 import org.apache.kafka.common.log.remote.storage.RemoteLogSegmentId;
 import org.apache.kafka.common.log.remote.storage.RemoteLogSegmentMetadata;
 import org.apache.kafka.common.log.remote.storage.RemoteStorageException;
-import org.apache.kafka.common.record.CompressionType;
-import org.apache.kafka.common.record.MemoryRecords;
-import org.apache.kafka.common.record.RecordBatch;
-import org.apache.kafka.common.record.SimpleRecord;
-import org.apache.kafka.common.record.TimestampType;
-import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.common.log.remote.storage.RemoteStorageManager;
 import org.apache.kafka.common.utils.Utils;
-
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.apache.kafka.test.TestUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
-import java.util.ArrayList;
+import java.nio.ByteBuffer;
+import java.nio.channels.SeekableByteChannel;
+import java.nio.file.Files;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class HDFSRemoteStorageManagerTest {
     private File logDir;
     private File remoteDir;
-    MiniDFSCluster hdfsCluster;
-    FileSystem hdfs;
-    String baseDir = "/localcluster";
-    private HashMap<String, String> config;
-    private ArrayList<LogSegment> segments = new ArrayList<>();
-    private int leaderEpoch = 1;
+    private MiniDFSCluster hdfsCluster;
+    private FileSystem hdfs;
+    private final String baseDir = "/kafka-remote-logs";
+    private Map<String, String> config;
 
-    @Before
+    private RemoteStorageManager rsm;
+
+    @BeforeEach
     public void setup() throws Exception {
-        logDir = TestUtils.tempDir();
-        remoteDir = TestUtils.tempDir();
+        logDir = TestUtils.tempDirectory();
+        remoteDir = TestUtils.tempDirectory();
 
         Configuration conf = new Configuration();
         conf.set(MiniDFSCluster.HDFS_MINIDFS_BASEDIR, remoteDir.getAbsolutePath());
@@ -77,40 +76,15 @@ public class HDFSRemoteStorageManagerTest {
         String hdfsURI = "hdfs://localhost:" + hdfsCluster.getNameNodePort() + "/";
         hdfs = FileSystem.newInstance(new URI(hdfsURI), conf);
 
-        LogSegment seg1 = LogUtils.createSegment(0, logDir, 4096, Time.SYSTEM);
-        appendRecords(seg1, 0, 100, 0);
-        appendRecords(seg1, 200, 100, 1000);
-        seg1.onBecomeInactiveSegment();
-        segments.add(seg1);
-
-        LogSegment seg2 = LogUtils.createSegment(300, logDir, 4096, Time.SYSTEM);
-        appendRecords(seg2, 400, 100, 2000);
-        seg2.onBecomeInactiveSegment();
-        segments.add(seg2);
-
         config = new HashMap<>();
         config.put(HDFSRemoteStorageManagerConfig.HDFS_URI_PROP, hdfsURI);
         config.put(HDFSRemoteStorageManagerConfig.HDFS_BASE_DIR_PROP, baseDir);
+
+        rsm = new HDFSRemoteStorageManager();
+        rsm.configure(config);
     }
 
-    private void appendRecords(LogSegment seg, long offset, int numRecords) {
-        appendRecords(seg, offset, numRecords, 0L);
-    }
-
-    private void appendRecords(LogSegment seg, long offset, int numRecords, long baseTimestamp) {
-        SimpleRecord[] records = new SimpleRecord[numRecords];
-        long timestamp = baseTimestamp;
-        for (int i = 0; i < numRecords; i++) {
-            timestamp = baseTimestamp + i;
-            records[i] = new SimpleRecord(timestamp, new byte[100]);
-        }
-        long lastOffset = offset + numRecords - 1;
-        seg.append(lastOffset, timestamp, offset,
-            MemoryRecords.withRecords(RecordBatch.CURRENT_MAGIC_VALUE, offset, CompressionType.NONE,
-                TimestampType.CREATE_TIME, records));
-    }
-
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         hdfsCluster.shutdown();
         Utils.delete(logDir);
@@ -118,89 +92,253 @@ public class HDFSRemoteStorageManagerTest {
     }
 
     @Test
-    public void testConfigAndClose() {
-        HDFSRemoteStorageManager rsm = new HDFSRemoteStorageManager();
+    public void testConfigAndClose() throws Exception {
+        RemoteStorageManager rsm = new HDFSRemoteStorageManager();
         rsm.configure(config);
         rsm.close();
     }
 
-    private LogSegmentData getLogSegmentData(LogSegment seg) {
-        return new LogSegmentData(seg.log().file(), seg.offsetIndex().file(), seg.timeIndex().file(), seg.txnIndex().file(), null, null);
+    @Test
+    public void testCopyReadAndDelete() throws Exception {
+        TopicPartition tp = new TopicPartition("test", 1);
+        UUID uuid = UUID.randomUUID();
+        RemoteLogSegmentMetadata metadata = verifyUpload(rsm, tp, uuid, 0, 1000, true);
+        verifyDeleteRemoteLogSegment(rsm, metadata, tp, uuid);
     }
 
-    private void assertFileEquals(InputStream is, File f) throws Exception {
-        byte[] b0 = new byte[1000000];
-        byte[] b1 = new byte[1000000];
+    @Test
+    public void testCopyReadAndDeleteWithMultipleSegments() throws Exception {
+        TopicPartition tp = new TopicPartition("test", 1);
+        UUID uuid0 = UUID.randomUUID();
+        RemoteLogSegmentMetadata metadata0 = verifyUpload(rsm, tp, uuid0, 0, 1000, true);
+        UUID uuid1 = UUID.randomUUID();
+        RemoteLogSegmentMetadata metadata1 = verifyUpload(rsm, tp, uuid1, 1000, 2000, true);
+        verifyDeleteRemoteLogSegment(rsm, metadata0, tp, uuid0);
+        verifyDeleteRemoteLogSegment(rsm, metadata1, tp, uuid1);
+    }
 
-        try (InputStream is1 = new FileInputStream(f)) {
-            long p = 0;
-            while (p < f.length()) {
-                long a = is.read(b0);
-                long b = is1.read(b1);
-                assertEquals(a, b);
-                assertArrayEquals(b0, b1);
-                p += a;
-            }
+    @Test
+    public void testCopyReadAndDeleteWithoutOptionalFiles() throws Exception {
+        TopicPartition tp = new TopicPartition("test", 1);
+        UUID uuid = UUID.randomUUID();
+        RemoteLogSegmentMetadata metadata = verifyUpload(rsm, tp, uuid, 0, 1000, false);
+        verifyDeleteRemoteLogSegment(rsm, metadata, tp, uuid);
+    }
+
+    @Test
+    public void testFetchOnOptionalFile() throws Exception {
+        TopicPartition tp = new TopicPartition("test", 1);
+        UUID uuid = UUID.randomUUID();
+        RemoteLogSegmentMetadata metadata = verifyUpload(rsm, tp, uuid, 0, 1000, false);
+        try (InputStream stream = rsm.fetchOffsetIndex(metadata)) {
+            assertNotEquals(0, stream.available());
+        }
+        try (InputStream stream = rsm.fetchTransactionIndex(metadata)) {
+            assertEquals(0, stream.available());
         }
     }
 
     @Test
-    public void testCopyReadAndDelete() throws Exception {
+    public void testFetchLogSegment() throws Exception {
+        TopicPartition tp = new TopicPartition("test", 1);
+        UUID uuid = UUID.randomUUID();
+        int segSize = 1000;
+        RemoteLogSegmentId id = new RemoteLogSegmentId(tp, uuid);
+        RemoteLogSegmentMetadata segmentMetadata = new RemoteLogSegmentMetadata(id,
+                0, 100, 0, 0, segSize, Collections.emptyMap());
+        LogSegmentData segmentData = TestLogSegmentUtils.createLogSegmentData(logDir, 0, segSize, false);
+        rsm.copyLogSegment(segmentMetadata, segmentData);
+
+        // start and end position are both inclusive in RSM
+        // full fetch segment
+        verifyFetchLogSegment(rsm, segmentMetadata, segmentData, 0L, 999L, 1000);
+        // fetch intermediate segment
+        verifyFetchLogSegment(rsm, segmentMetadata, segmentData, 100L, 199L, 100);
+        // fetch till the end of the segment
+        verifyFetchLogSegment(rsm, segmentMetadata, segmentData, 990L, 999L, 10);
+        // fetch exceeds the segment size
+        verifyFetchLogSegment(rsm, segmentMetadata, segmentData, 990L, 1050L, 10);
+    }
+    
+    @Test
+    public void testRepeatedFetchReadsFromCacheOnFullSegmentFetch() throws Exception {
+        LRUCacheWithContext cache = new LRUCacheWithContext(10 * 1048576L);
+        // two cache hits due to the additional 25 bytes read for the header exceeds the defined cache line size of 2MB.
+        testRepeatedCacheReads(cache, "2", 2097152, 2);
+    }
+
+    @Test
+    public void testRepeatedFetchReadsFromCacheOnSegmentSizeLessThanCacheLine() throws Exception {
+        LRUCacheWithContext cache = new LRUCacheWithContext(10 * 1048576L);
+        testRepeatedCacheReads(cache, "1", 1024, 1);
+    }
+
+    private void testRepeatedCacheReads(LRUCacheWithContext cache,
+                                        String cacheLineSizeInMb,
+                                        int segSize,
+                                        int expectedCacheHit) throws Exception {
+        config.put(HDFSRemoteStorageManagerConfig.HDFS_REMOTE_READ_MB_PROP, cacheLineSizeInMb);
         HDFSRemoteStorageManager rsm = new HDFSRemoteStorageManager();
         rsm.configure(config);
+        rsm.setLRUCache(cache);
 
         TopicPartition tp = new TopicPartition("test", 1);
+        UUID uuid = UUID.randomUUID();
+        RemoteLogSegmentId id = new RemoteLogSegmentId(tp, uuid);
+        RemoteLogSegmentMetadata segmentMetadata = new RemoteLogSegmentMetadata(id,
+                0, 100, 0, 0, segSize, Collections.emptyMap());
+        LogSegmentData segmentData = TestLogSegmentUtils.createLogSegmentData(logDir, 0, segSize, false);
+        rsm.copyLogSegment(segmentMetadata, segmentData);
 
-        UUID uuid0 = UUID.randomUUID();
-        RemoteLogSegmentId id0 = new RemoteLogSegmentId(tp, uuid0);
-        LogSegmentData seg0 = getLogSegmentData(segments.get(0));
-        RemoteLogSegmentMetadata seg0metadata = new RemoteLogSegmentMetadata(id0, 0, 299, 0, 0, 1L, Collections.emptyMap());
-        rsm.copyLogSegment(seg0metadata, seg0);
+        assertEquals(0, cache.getCacheHit());
+        verifyFetchLogSegment(rsm, segmentMetadata, segmentData, 0L, Long.MAX_VALUE, segSize);
+        assertEquals(0, cache.getCacheHit());
 
-        assertTrue(hdfs.exists(new Path(baseDir + "/test-1")));
-        assertTrue(hdfs.exists(new Path(baseDir + "/test-1/" + uuid0 + "/log")));
-        assertTrue(hdfs.exists(new Path(baseDir + "/test-1/" + uuid0 + "/index")));
-        assertTrue(hdfs.exists(new Path(baseDir + "/test-1/" + uuid0 + "/timeindex")));
+        // read from cache
+        verifyFetchLogSegment(rsm, segmentMetadata, segmentData, 0L, Long.MAX_VALUE, segSize);
+        // two cache hits due to the additional 25 bytes read for the header.
+        assertEquals(expectedCacheHit, cache.getCacheHit());
+    }
 
-        UUID uuid1 = UUID.randomUUID();
-        RemoteLogSegmentId id1 = new RemoteLogSegmentId(tp, uuid1);
-        RemoteLogSegmentMetadata seg1metadata = new RemoteLogSegmentMetadata(id1, 300, 499, 0, 0, 1L, Collections.emptyMap());
-        LogSegmentData seg1 = getLogSegmentData(segments.get(1));
-        rsm.copyLogSegment(seg1metadata, seg1);
-        assertTrue(hdfs.exists(new Path(baseDir + "/test-1/" + uuid1 + "/index")));
-
-        try (InputStream is = rsm.fetchLogSegmentData(seg0metadata, 0L, Long.MAX_VALUE)) {
-            assertFileEquals(is, segments.get(0).log().file());
+    /**
+     * Verifies the log segment fetch.
+     * @param rsm           remote storage manager
+     * @param metadata      metadata about the remote log segment.
+     * @param segmentData   segment data.
+     * @param startPosition start position to fetch from the segment, inclusive
+     * @param endPosition   Fetch data till the end position, inclusive
+     * @throws Exception I/O Error, file not found exception.
+     */
+    private void verifyFetchLogSegment(RemoteStorageManager rsm,
+                                       RemoteLogSegmentMetadata metadata,
+                                       LogSegmentData segmentData,
+                                       long startPosition,
+                                       long endPosition,
+                                       int size) throws Exception {
+        try (InputStream stream = rsm.fetchLogSegmentData(metadata, startPosition, endPosition)) {
+            ByteBuffer buffer = ByteBuffer.wrap(new byte[size]);
+            SeekableByteChannel byteChannel = Files.newByteChannel(segmentData.logSegment().toPath());
+            byteChannel.position(startPosition);
+            byteChannel.read(buffer);
+            buffer.rewind();
+            assertDataEquals(buffer, stream);
         }
-        try (InputStream is = rsm.fetchOffsetIndex(seg0metadata)) {
-            assertFileEquals(is, segments.get(0).offsetIndex().file());
+    }
+
+    private RemoteLogSegmentMetadata verifyUpload(RemoteStorageManager rsm,
+                                                  TopicPartition tp,
+                                                  UUID uuid,
+                                                  int startOffset,
+                                                  int segSize,
+                                                  boolean withOptionalFiles) throws Exception {
+        RemoteLogSegmentId id = new RemoteLogSegmentId(tp, uuid);
+        RemoteLogSegmentMetadata segmentMetadata = new RemoteLogSegmentMetadata(id,
+                0, 100, 0, 0, segSize, Collections.emptyMap());
+        LogSegmentData segmentData = TestLogSegmentUtils
+                .createLogSegmentData(logDir, startOffset, segSize, withOptionalFiles);
+        rsm.copyLogSegment(segmentMetadata, segmentData);
+        checkFileExistence(uuid);
+        checkAssociatedFileContents(rsm, segmentMetadata, segmentData);
+        assertTrue(hdfs.exists(new Path(baseDir + File.separator + tp.toString() + File.separator + uuid)));
+        return segmentMetadata;
+    }
+
+    private void verifyDeleteRemoteLogSegment(RemoteStorageManager rsm,
+                                              RemoteLogSegmentMetadata metadata,
+                                              TopicPartition tp,
+                                              UUID uuid) throws RemoteStorageException, IOException {
+        rsm.deleteLogSegment(metadata);
+        assertFalse(hdfs.exists(new Path(baseDir + File.separator + tp.toString() + File.separator + uuid)));
+        RemoteStorageException ex = assertThrows(RemoteStorageException.class,
+                () -> rsm.fetchLogSegmentData(metadata, 0L, Long.MAX_VALUE));
+        assertEquals("Failed to fetch SEGMENT file from remote storage", ex.getMessage());
+        ex = assertThrows(RemoteStorageException.class,
+                () -> rsm.fetchOffsetIndex(metadata));
+        assertEquals("Failed to fetch OFFSET_INDEX file from remote storage", ex.getMessage());
+    }
+
+    private void checkFileExistence(UUID uuid) throws IOException {
+        Path path = new Path(baseDir, "test-1");
+        assertTrue(hdfs.exists(path));
+
+        Path filePath = new Path(path, uuid.toString());
+        assertTrue(hdfs.exists(filePath));
+
+        int count = 0;
+        RemoteIterator<LocatedFileStatus> iter = hdfs.listFiles(filePath, true);
+        while (iter.hasNext()) {
+            iter.next();
+            count++;
         }
-        try (InputStream is = rsm.fetchTimestampIndex(seg0metadata)) {
-            assertFileEquals(is, segments.get(0).timeIndex().file());
+        assertEquals(1, count);
+    }
+
+    private void checkAssociatedFileContents(RemoteStorageManager rsm,
+                                             RemoteLogSegmentMetadata metadata,
+                                             LogSegmentData segmentData) throws Exception {
+        try (InputStream actualStream = rsm.fetchLogSegmentData(metadata, 0L, Long.MAX_VALUE)) {
+            assertFileEquals(segmentData.logSegment(), actualStream);
+        }
+        try (InputStream actualStream = rsm.fetchOffsetIndex(metadata)) {
+            assertFileEquals(segmentData.offsetIndex(), actualStream);
+        }
+        try (InputStream actualStream = rsm.fetchTimestampIndex(metadata)) {
+            assertFileEquals(segmentData.timeIndex(), actualStream);
+        }
+        try (InputStream actualStream = rsm.fetchLeaderEpochIndex(metadata)) {
+            assertFileEquals(segmentData.leaderEpochCheckpoint(), actualStream);
+        }
+        if (segmentData.txnIndex() != null) {
+            try (InputStream actualStream = rsm.fetchTransactionIndex(metadata)) {
+                assertFileEquals(segmentData.txnIndex(), actualStream);
+            }
+        }
+        if (segmentData.producerIdSnapshotIndex() != null) {
+            try (InputStream actualStream = rsm.fetchProducerSnapshotIndex(metadata)) {
+                assertFileEquals(segmentData.producerIdSnapshotIndex(), actualStream);
+            }
+        }
+    }
+
+    private void assertFileEquals(File expected, InputStream actual) throws Exception {
+        byte[] expectedBuffer = new byte[1_000_000];
+        byte[] actualBuffer = new byte[1_000_000];
+        try (InputStream is1 = new FileInputStream(expected)) {
+            long bytesRead = 0;
+            while (bytesRead < expected.length()) {
+                long expectedBytesRead = is1.read(expectedBuffer);
+                long actualBytesRead = actual.read(actualBuffer);
+                assertEquals(expectedBytesRead, actualBytesRead);
+                assertArrayEquals(expectedBuffer, actualBuffer);
+                bytesRead += expectedBytesRead;
+            }
+        }
+    }
+
+    private void assertDataEquals(ByteBuffer expectedBuffer, InputStream actual) throws Exception {
+        ByteBuffer actualBuffer = ByteBuffer.wrap(new byte[actual.available()]);
+        int read = actual.read(actualBuffer.array());
+        assertEquals(expectedBuffer.limit(), read);
+        assertEquals(expectedBuffer, actualBuffer);
+    }
+
+    private static class LRUCacheWithContext extends LRUCache {
+        private int cacheHit = 0;
+
+        private LRUCacheWithContext(long maxBytes) {
+            super(maxBytes);
         }
 
-        try (InputStream is = rsm.fetchLogSegmentData(seg1metadata, 0L, Long.MAX_VALUE)) {
-            assertFileEquals(is, segments.get(1).log().file());
-        }
-        try (InputStream is = rsm.fetchOffsetIndex(seg1metadata)) {
-            assertFileEquals(is, segments.get(1).offsetIndex().file());
-        }
-        try (InputStream is = rsm.fetchTimestampIndex(seg1metadata)) {
-            assertFileEquals(is, segments.get(1).timeIndex().file());
+        synchronized byte[] get(String path, long offset) {
+            byte[] result = super.get(path, offset);
+            if (result != null) {
+                cacheHit++;
+            }
+            return result;
         }
 
-        assertTrue(hdfs.exists(new Path(baseDir + "/test-1/" + uuid0)));
-        assertTrue(hdfs.exists(new Path(baseDir + "/test-1/" + uuid1)));
-        rsm.deleteLogSegment(seg0metadata);
-        rsm.deleteLogSegment(seg1metadata);
-        assertFalse(hdfs.exists(new Path(baseDir + "/test-1/" + uuid0)));
-        assertFalse(hdfs.exists(new Path(baseDir + "/test-1/" + uuid1)));
-
-        assertThrows(RemoteStorageException.class, () -> {
-            rsm.fetchLogSegmentData(seg0metadata, 0L, Long.MAX_VALUE);
-        });
-        assertThrows(RemoteStorageException.class, () -> {
-            rsm.fetchOffsetIndex(seg1metadata);
-        });
+        public int getCacheHit() {
+            return cacheHit;
+        }
     }
 }

--- a/remote-storage-managers/hdfs/src/test/java/org/apache/kafka/rsm/hdfs/LRUCacheTest.java
+++ b/remote-storage-managers/hdfs/src/test/java/org/apache/kafka/rsm/hdfs/LRUCacheTest.java
@@ -16,14 +16,15 @@
  */
 package org.apache.kafka.rsm.hdfs;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class LRUCacheTest {
+
     @Test
     public void testLRUCache() {
         LRUCache cache = new LRUCache(1000);

--- a/remote-storage-managers/hdfs/src/test/java/org/apache/kafka/rsm/hdfs/LogSegmentDataHeaderTest.java
+++ b/remote-storage-managers/hdfs/src/test/java/org/apache/kafka/rsm/hdfs/LogSegmentDataHeaderTest.java
@@ -1,0 +1,68 @@
+package org.apache.kafka.rsm.hdfs;
+
+import org.apache.kafka.common.log.remote.storage.LogSegmentData;
+import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.test.TestUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class LogSegmentDataHeaderTest {
+
+    private File logDir;
+
+    @BeforeEach
+    public void before() {
+        logDir = TestUtils.tempDirectory();
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception {
+        Utils.delete(logDir);
+    }
+
+    @Test
+    void getDataPosition() throws IOException {
+        LogSegmentDataHeader dataHeader = createLogSegmentHeader(true);
+        int startPos = LogSegmentDataHeader.LENGTH;
+        int idxFileSize = 10;
+        for (LogSegmentDataHeader.FileType fileType : LogSegmentDataHeader.FileType.values()) {
+            LogSegmentDataHeader.DataPosition dataPosition = dataHeader.getDataPosition(fileType);
+            int length = fileType == LogSegmentDataHeader.FileType.SEGMENT ? Integer.MAX_VALUE : idxFileSize;
+            assertEquals(new LogSegmentDataHeader.DataPosition(startPos, length), dataPosition);
+            startPos += length;
+        }
+    }
+
+    @Test
+    void testSerde() throws IOException {
+        LogSegmentDataHeader expected = createLogSegmentHeader(true);
+        byte[] serializedBytes = LogSegmentDataHeader.serialize(expected);
+        LogSegmentDataHeader actual = LogSegmentDataHeader.deserialize(ByteBuffer.wrap(serializedBytes));
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void testCreateLogSegmentDataHeaderWithoutOptionalFiles() throws IOException {
+        createLogSegmentHeader(false);
+    }
+
+    @Test
+    void testCreateLogSegmentDataHeader() throws IOException {
+        createLogSegmentHeader(true);
+    }
+
+    private LogSegmentDataHeader createLogSegmentHeader(boolean withOptional) throws IOException {
+        LogSegmentData segmentData = TestLogSegmentUtils.createLogSegmentData(logDir, 0, 1000, withOptional);
+        LogSegmentDataHeader dataHeader = LogSegmentDataHeader.create(segmentData);
+        assertEquals(LogSegmentDataHeader.CURRENT_VERSION, dataHeader.version());
+        assertEquals(6, dataHeader.filePositions().size());
+        return dataHeader;
+    }
+}

--- a/remote-storage-managers/hdfs/src/test/java/org/apache/kafka/rsm/hdfs/TestLogSegmentUtils.java
+++ b/remote-storage-managers/hdfs/src/test/java/org/apache/kafka/rsm/hdfs/TestLogSegmentUtils.java
@@ -1,0 +1,45 @@
+package org.apache.kafka.rsm.hdfs;
+
+import org.apache.kafka.common.log.remote.storage.LogSegmentData;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+
+import static org.apache.kafka.rsm.hdfs.HDFSRemoteStorageManager.LEADER_EPOCH_FILE_NAME;
+import static org.apache.kafka.rsm.hdfs.HDFSRemoteStorageManager.LOG_FILE_NAME;
+import static org.apache.kafka.rsm.hdfs.HDFSRemoteStorageManager.OFFSET_INDEX_FILE_NAME;
+import static org.apache.kafka.rsm.hdfs.HDFSRemoteStorageManager.PRODUCER_SNAPSHOT_FILE_NAME;
+import static org.apache.kafka.rsm.hdfs.HDFSRemoteStorageManager.TIME_INDEX_FILE_NAME;
+import static org.apache.kafka.rsm.hdfs.HDFSRemoteStorageManager.TXN_INDEX_FILE_NAME;
+
+public class TestLogSegmentUtils {
+
+    public static LogSegmentData createLogSegmentData(File logDir,
+                                                      int startOffset,
+                                                      int segSize,
+                                                      boolean withOptionalFiles) throws IOException {
+        String prefix = String.format("%020d", startOffset);
+        File segment = new File(logDir, prefix + "." + LOG_FILE_NAME);
+        Files.write(segment.toPath(), kafka.utils.TestUtils.randomBytes(segSize));
+
+        File offsetIndex = new File(logDir, prefix + "." + OFFSET_INDEX_FILE_NAME);
+        Files.write(offsetIndex.toPath(), kafka.utils.TestUtils.randomBytes(10));
+
+        File timeIndex = new File(logDir, prefix + "." + TIME_INDEX_FILE_NAME);
+        Files.write(timeIndex.toPath(), kafka.utils.TestUtils.randomBytes(10));
+
+        File leaderEpochIndex = new File(logDir, prefix + "." + LEADER_EPOCH_FILE_NAME);
+        Files.write(leaderEpochIndex.toPath(), kafka.utils.TestUtils.randomBytes(10));
+
+        File txnIndex = null;
+        File producerSnapshotIndex = null;
+        if (withOptionalFiles) {
+            txnIndex = new File(logDir, prefix + "." + TXN_INDEX_FILE_NAME);
+            producerSnapshotIndex = new File(logDir, prefix + "." + PRODUCER_SNAPSHOT_FILE_NAME);
+            Files.write(txnIndex.toPath(), kafka.utils.TestUtils.randomBytes(10));
+            Files.write(producerSnapshotIndex.toPath(), kafka.utils.TestUtils.randomBytes(10));
+        }
+        return new LogSegmentData(segment, offsetIndex, timeIndex, txnIndex, producerSnapshotIndex, leaderEpochIndex);
+    }
+}

--- a/remote-storage-managers/hdfs/src/test/resources/log4j.properties
+++ b/remote-storage-managers/hdfs/src/test/resources/log4j.properties
@@ -1,0 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+log4j.rootLogger=OFF, stdout
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c:%L)%n
+
+log4j.logger.org.apache.kafka=ERROR


### PR DESCRIPTION
- The associated files for a segment such as an offset index, transaction index, timestamp index, producer snapshot,
   leader epoch checkpoint are appended to a single HDFS file to avoid small files problem in Hadoop.
- Storing small files in HDFS can take a hit on its efficiency as each file/dir/block is represented as an object in
   NameNode's memory which occupies 150 bytes. Moreover, the default HDFS block size is 64 MB and Kafka Index 
   files are 10 MB.