### PR TITLE
Enable RLMM to connect to secured Kafka Cluster

### DIFF
--- a/core/src/main/scala/kafka/server/KafkaServer.scala
+++ b/core/src/main/scala/kafka/server/KafkaServer.scala
@@ -427,7 +427,7 @@ class KafkaServer(val config: KafkaConfig, time: Time = Time.SYSTEM, threadNameP
         val serverEndpoint = remoteLogManagerConfig.listenerName.map(ListenerName.normalised)
           .map(l => brokerInfo.broker.endPoint(l)) // if no listener is found it throws BrokerEndPointNotAvailableException
           .getOrElse(brokerInfo.broker.endPoints.head) // if no listener is configured, then return the first endpoint.
-        remoteLogManager.foreach(rlm => rlm.onEndpointCreated(serverEndpoint.host + ":" + serverEndpoint.port))
+        remoteLogManager.foreach(rlm => rlm.onEndpointCreated(serverEndpoint))
 
         socketServer.startProcessingRequests(authorizerFutures)
 

--- a/core/src/test/scala/kafka/log/remote/RemoteMetadataLogTest.scala
+++ b/core/src/test/scala/kafka/log/remote/RemoteMetadataLogTest.scala
@@ -1,13 +1,14 @@
 package kafka.log.remote
 
+import kafka.server.KafkaConfig
 import kafka.utils.{MockTime, TestUtils}
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.log.remote.storage.{RemoteLogSegmentId, RemoteLogSegmentMetadata}
 import org.apache.kafka.common.record.SimpleRecord
-import org.junit.jupiter.api.Assertions.{assertEquals, assertTrue}
+import org.junit.jupiter.api.Assertions.{assertEquals, assertFalse, assertTrue}
 import org.junit.jupiter.api.Test
 
-import java.util.{Collections, UUID}
+import java.util.{Collections, Properties, UUID}
 import scala.jdk.CollectionConverters._
 
 class RemoteMetadataLogTest {
@@ -44,5 +45,59 @@ class RemoteMetadataLogTest {
     val actual = RemoteMetadataLog.formatRecordKeyAndValue(remoteLogMetadataRecord)
     assertTrue(actual._1.get.isEmpty)
     assertEquals("<EMPTY>", actual._2.get)
+  }
+
+  @Test
+  def testRLMConfig(): Unit = {
+    val m: Map[String, String] = Map(
+      "advertised.host.name" -> "ducker03",
+      "advertised.listeners" -> "SASL_SSL://ducker03:9095",
+      "broker.id" -> "1",
+      "group.initial.rebalance.delay.ms" -> "100",
+      "inter.broker.listener.name" -> "SASL_SSL",
+      "listener.security.protocol.map" -> "SASL_SSL:SASL_SSL",
+      "listeners" -> "SASL_SSL://:9095",
+      "log.dirs, /mnt/kafka/kafka-data-logs-1" -> "/mnt/kafka/kafka-data-logs-2",
+      "offsets.topic.num.partitions" -> "3",
+      "offsets.topic.replication.factor" -> "3",
+      "port" -> "9092",
+      "sasl.enabled.mechanisms" -> "GSSAPI",
+      "sasl.kerberos.service.name" -> "kafka",
+      "sasl.mechanism.inter.broker.protocol" -> "GSSAPI",
+      "socket.receive.buffer.bytes" -> "65536",
+      "ssl.endpoint.identification.algorithm" -> "HTTPS",
+      "ssl.key.password" -> "test-ks-passwd",
+      "ssl.keystore.location" -> "/mnt/security/test.keystore.jks",
+      "ssl.keystore.password" -> "test-ks-passwd",
+      "ssl.keystore.type" -> "JKS",
+      "ssl.truststore.location" -> "/mnt/security/test.truststore.jks",
+      "ssl.truststore.password" -> "test-ts-passwd",
+      "ssl.truststore.type" -> "JKS",
+      "zookeeper.connect" -> "ducker02:2181",
+      "zookeeper.connection.timeout.ms" -> "18000",
+      "zookeeper.session.timeout.ms" -> "18000",
+      "zookeeper.set.acl" -> "false",
+      "zookeeper.ssl.client.enable" -> "false",
+      "zookeeper.ssl.keystore.location" -> "/mnt/security/test.keystore.jks",
+      "zookeeper.ssl.keystore.password" -> "test-ks-passwd",
+      "zookeeper.ssl.truststore.location" -> "/mnt/security/test.truststore.jks",
+      "zookeeper.ssl.truststore.password" -> "test-ts-passwd",
+      "remote.log.metadata.hello" -> "world",
+      "remote.log.x.y" -> "z"
+    )
+    val props: Properties = new Properties()
+    m.foreach {
+      case (k, v) => props.put(k, v)
+    }
+
+    val keys: Array[String] = Array("ssl.truststore.location", "sasl.kerberos.service.name", "remote.log.metadata.hello")
+    val rlm = RemoteLogManager.createRemoteLogManagerConfig(KafkaConfig.fromProps(props))
+    for (key <- keys) {
+      assertEquals(m.get(key), rlm.rlmmProps.get(key))
+    }
+    assertFalse(rlm.rlmmProps.contains("remote.log.x.y"))
+    rlm.rlmmProps.foreach {
+      case(k, v) => println("%s=%s".format(k, v))
+    }
   }
 }

--- a/core/src/test/scala/unit/kafka/log/remote/RemoteLogManagerTest.scala
+++ b/core/src/test/scala/unit/kafka/log/remote/RemoteLogManagerTest.scala
@@ -23,6 +23,7 @@ import java.util.function.Consumer
 import java.util.{Collections, Optional, Properties}
 import java.{lang, util}
 
+import kafka.cluster.EndPoint
 import kafka.log.remote.RemoteLogManager.REMOTE_STORAGE_MANAGER_CONFIG_PREFIX
 import kafka.log._
 import kafka.server.QuotaFactory.UnboundedQuota
@@ -34,8 +35,10 @@ import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.log.remote.storage._
 import org.apache.kafka.common.message.LeaderAndIsrRequestData.LeaderAndIsrPartitionState
 import org.apache.kafka.common.metrics.Metrics
+import org.apache.kafka.common.network.ListenerName
 import org.apache.kafka.common.record._
 import org.apache.kafka.common.requests.FetchRequest.PartitionData
+import org.apache.kafka.common.security.auth.SecurityProtocol
 import org.apache.kafka.common.utils.Utils
 import org.easymock.EasyMock
 import org.junit.Assert._
@@ -122,7 +125,8 @@ class RemoteLogManagerTest {
     // this should initialize RSM
     val logsDirTmp = Files.createTempDirectory("kafka-").toString
     val remoteLogManager = new RemoteLogManager(logFetcher, lsoUpdater, rlmConfig, time, 1, "", logsDirTmp, new BrokerTopicStats)
-    remoteLogManager.onEndpointCreated("localhost:9092")
+    val securityProtocol = SecurityProtocol.PLAINTEXT
+    remoteLogManager.onEndpointCreated(EndPoint( "localhost", 9092, ListenerName.forSecurityProtocol(securityProtocol), securityProtocol))
 
     assertTrue(rsmConfig.count { case (k, v) => MockRemoteStorageManager.configs.get(k) == v } == rsmConfig.size)
     assertEquals(MockRemoteStorageManager.configs.get(KafkaConfig.RemoteLogRetentionBytesProp),

--- a/tests/kafkatest/services/hadoop/mini_hadoop.py
+++ b/tests/kafkatest/services/hadoop/mini_hadoop.py
@@ -188,7 +188,8 @@ class MiniHadoop(Service):
             "HADOOP_OS_TYPE": "${HADOOP_OS_TYPE:-$(uname -s)}",
             "HADOOP_GC_SETTINGS": "-verbose:gc -XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps",
             "HDFS_NAMENODE_OPTS": "${HADOOP_GC_SETTINGS} -Xloggc:${HADOOP_LOG_DIR}/gc-rm.log-$(date +'%Y%m%d%H%M') "
-                                  "-Dhadoop.security.logger=INFO,RFAS"
+                                  "-Dhadoop.security.logger=INFO,RFAS",
+            "HADOOP_HEAPSIZE_MAX": "256m"
         }
         return self.render(template_name, kwargs=kwargs)
 

--- a/tests/kafkatest/services/kafka/kafka.py
+++ b/tests/kafkatest/services/kafka/kafka.py
@@ -268,12 +268,9 @@ class KafkaService(KafkaPathResolverMixin, JmxMixin, Service):
 
         self.logger.info("Waiting for brokers to register at ZK")
 
-        retries = 30
         expected_broker_ids = set(self.nodes)
-        wait_until(lambda: {node for node in self.nodes if self.is_registered(node)} == expected_broker_ids, 30, 1)
-
-        if retries == 0:
-            raise RuntimeError("Kafka servers didn't register at ZK within 30 seconds")
+        wait_until(lambda: {node for node in self.nodes if self.is_registered(node)} == expected_broker_ids,
+                   timeout_sec=30, backoff_sec=1, err_msg="Kafka servers didn't register at ZK within 30 seconds")
 
         # Create topics if necessary
         if self.topics is not None:

--- a/tests/kafkatest/tests/core/tiered_replication_test.py
+++ b/tests/kafkatest/tests/core/tiered_replication_test.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from kafkatest.tests.core.replication_test import ReplicationTest, clean_shutdown, matrix, cluster, failures
+from kafkatest.tests.core.replication_test import ReplicationTest, clean_shutdown, matrix, parametrize, cluster, failures
 from kafkatest.services.hadoop import MiniHadoop
 from kafkatest.services.kafka import config_property
 
@@ -23,11 +23,25 @@ class TieredReplicationTest(ReplicationTest):
     def __init__(self, test_context):
         super(TieredReplicationTest, self).__init__(test_context)
 
-    @cluster(num_nodes=9)
+    @cluster(num_nodes=10)
     @matrix(failure_mode=["clean_shutdown", "hard_shutdown", "clean_bounce", "hard_bounce"],
             broker_type=["leader"],
             security_protocol=["PLAINTEXT"],
-            enable_idempotence=[True, False])
+            enable_idempotence=[True])
+    @matrix(failure_mode=["clean_shutdown", "hard_shutdown", "clean_bounce", "hard_bounce"],
+            broker_type=["leader"],
+            security_protocol=["PLAINTEXT", "SASL_SSL"])
+    @matrix(failure_mode=["clean_shutdown", "hard_shutdown", "clean_bounce", "hard_bounce"],
+            broker_type=["controller"],
+            security_protocol=["PLAINTEXT", "SASL_SSL"])
+    @matrix(failure_mode=["hard_bounce"],
+            broker_type=["leader"],
+            security_protocol=["SASL_SSL"], client_sasl_mechanism=["PLAIN"], interbroker_sasl_mechanism=["PLAIN", "GSSAPI"])
+    @parametrize(failure_mode="hard_bounce",
+                 broker_type="leader",
+                 security_protocol="SASL_SSL", client_sasl_mechanism="SCRAM-SHA-256", interbroker_sasl_mechanism="SCRAM-SHA-512")
+    @matrix(failure_mode=["clean_shutdown", "hard_shutdown", "clean_bounce", "hard_bounce"],
+            security_protocol=["PLAINTEXT"], broker_type=["leader"], compression_type=["gzip"], tls_version=["TLSv1.2", "TLSv1.3"])
     def test_replication_with_broker_failure(self, failure_mode, security_protocol, broker_type,
                                              client_sasl_mechanism="GSSAPI", interbroker_sasl_mechanism="GSSAPI",
                                              compression_type=None, enable_idempotence=False, tls_version=None):

--- a/tests/kafkatest/tests/core/tiered_replication_test.py
+++ b/tests/kafkatest/tests/core/tiered_replication_test.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from kafkatest.tests.core.replication_test import *
+from kafkatest.tests.core.replication_test import ReplicationTest, clean_shutdown, matrix, cluster, failures
 from kafkatest.services.hadoop import MiniHadoop
 from kafkatest.services.kafka import config_property
 
@@ -22,10 +22,12 @@ class TieredReplicationTest(ReplicationTest):
 
     def __init__(self, test_context):
         super(TieredReplicationTest, self).__init__(test_context)
-        self.logger.debug("My test context: %s", str(test_context))
 
-    @cluster(num_nodes=10)
-    @parametrize(failure_mode="clean_shutdown", broker_type="leader", security_protocol="PLAINTEXT")
+    @cluster(num_nodes=9)
+    @matrix(failure_mode=["clean_shutdown", "hard_shutdown", "clean_bounce", "hard_bounce"],
+            broker_type=["leader"],
+            security_protocol=["PLAINTEXT"],
+            enable_idempotence=[True, False])
     def test_replication_with_broker_failure(self, failure_mode, security_protocol, broker_type,
                                              client_sasl_mechanism="GSSAPI", interbroker_sasl_mechanism="GSSAPI",
                                              compression_type=None, enable_idempotence=False, tls_version=None):


### PR DESCRIPTION
Verified the patch by running the `tiered_replication_test` with SASL_SSL, SSL, and SASL_PLAINTEXT as security protocol and with client/inter-broker SASL mechanism as GSSAPI/PLAIN/SCRAM-SHA-256.

By default, `sasl.mechanism` is set to GSSAPI. If this mechanism is not enabled in the `sasl.enabled.mechanism` (or) user wants to run with a different mechanism, then `sasl.mechanism` config should be provided in the broker configuration.